### PR TITLE
Various code cleanups and add high-level wrappers

### DIFF
--- a/src/Elf_read.c
+++ b/src/Elf_read.c
@@ -26,7 +26,7 @@
 // #define MAX_MEM_SIZE (((uint64_t) 0x400) * ((uint64_t) 0x400) * ((uint64_t) 0x400))
 #define MAX_MEM_SIZE ((uint64_t) 0x90000000)
 
-static uint8_t mem_buf [MAX_MEM_SIZE];
+static char mem_buf [MAX_MEM_SIZE];
 
 // ================================================================
 // Load an ELF file.
@@ -224,7 +224,8 @@ int c_mem_load_elf (FILE          *logfile_fp,
 	    data = elf_getdata (scn, data);
 
 	    // Get the number of symbols in this section
-	    int symbols = shdr.sh_size / shdr.sh_entsize;
+	    // Should be uint64_t but gelf_getsym only takes an int
+	    int symbols = (int) (shdr.sh_size / shdr.sh_entsize);
 
 	    // search for the uart_default symbols we need to potentially modify.
 	    GElf_Sym sym;
@@ -255,25 +256,25 @@ int c_mem_load_elf (FILE          *logfile_fp,
 		if (logfile_fp != NULL) {
 		    fprintf (logfile_fp, "Writing symbols to:    symbol_table.txt\n");
 		}
-		if (p_features->pc_start == -1)
+		if ((~ p_features->pc_start) == 0) {
 		    if (logfile_fp != NULL) {
 			fprintf (logfile_fp, "    No '_start' label found\n");
 		    }
-		else
+		} else
 		    fprintf (fp_symbol_table, "_start    0x%0" PRIx64 "\n", p_features->pc_start);
 
-		if (p_features->pc_exit == -1)
+		if ((~ p_features->pc_exit) == 0) {
 		    if (logfile_fp != NULL) {
 			fprintf (logfile_fp, "    No 'exit' label found\n");
 		    }
-		else
+		} else
 		    fprintf (fp_symbol_table, "exit      0x%0" PRIx64 "\n", p_features->pc_exit);
 
-		if (p_features->tohost_addr == -1)
+		if ((~ p_features->tohost_addr) == 0) {
 		    if (logfile_fp != NULL) {
 			fprintf (logfile_fp, "    No 'tohost' symbol found\n");
 		    }
-		else
+		} else
 		    fprintf (fp_symbol_table, "tohost    0x%0" PRIx64 "\n", p_features->tohost_addr);
 
 		fclose (fp_symbol_table);

--- a/src/Elf_read.h
+++ b/src/Elf_read.h
@@ -7,8 +7,8 @@
 // Features of the ELF binary
 
 typedef struct {
-    uint8_t  *mem_buf;
-    int       bitwidth;
+    char     *mem_buf;
+    uint8_t   bitwidth;
     uint64_t  min_addr;
     uint64_t  max_addr;
 

--- a/src/RVDM.c
+++ b/src/RVDM.c
@@ -41,6 +41,7 @@ void dmi_write (uint16_t addr, uint32_t data)
 uint32_t  dmi_read  (uint16_t addr)
 {
     fprintf (stderr, "RVDM.c: dmi_read(): Not yet implemented\n");
+    return 0;
 }
 
 // ================================================================
@@ -182,17 +183,17 @@ uint32_t fn_mk_dmcontrol (bool       haltreq,
 			  bool       ndmreset,
 			  bool       dmactive)
 {
-    return ((  (haltreq         & 0x1)   << 31)
-	    | ((resumereq       & 0x1)   << 30)
-	    | ((hartreset       & 0x1)   << 29)
-	    | ((ackhavereset    & 0x1)   << 28)
-	    | ((hasel           & 0x1)   << 26)
-	    | ((hartsello       & 0x3FF) << 16)
-	    | ((hartselhi       & 0x3FF) <<  6)
-	    | ((setresethaltreq & 0x1)   <<  3)
-	    | ((clrresethaltreq & 0x1)   <<  2)
-	    | ((ndmreset        & 0x1)   <<  1)
-	    | ((dmactive        & 0x1)   <<  0));
+    return ((  (((uint32_t) haltreq)         & 0x1)   << 31)
+	    | ((((uint32_t) resumereq)       & 0x1)   << 30)
+	    | ((((uint32_t) hartreset)       & 0x1)   << 29)
+	    | ((((uint32_t) ackhavereset)    & 0x1)   << 28)
+	    | ((((uint32_t) hasel)           & 0x1)   << 26)
+	    | ((((uint32_t) hartsello)       & 0x3FF) << 16)
+	    | ((((uint32_t) hartselhi)       & 0x3FF) <<  6)
+	    | ((((uint32_t) setresethaltreq) & 0x1)   <<  3)
+	    | ((((uint32_t) clrresethaltreq) & 0x1)   <<  2)
+	    | ((((uint32_t) ndmreset)        & 0x1)   <<  1)
+	    | ((((uint32_t) dmactive)        & 0x1)   <<  0));
 }
 
 bool     fn_dmcontrol_haltreq         (uint32_t dm_word) { return ((dm_word >> 31) & 0x1); }
@@ -345,13 +346,13 @@ uint32_t fn_mk_command_access_reg (DM_command_access_reg_size  size,
 				   bool                        write,
 				   uint16_t                    regno)
 {
-    return ((DM_COMMAND_CMDTYPE_ACCESS_REG << 24)
-	    | ((size             & 0x7)    << 20)
-	    | ((aarpostincrement & 0x1)    << 19)
-	    | ((postexec         & 0x1)    << 18)
-	    | ((transfer         & 0x1)    << 17)
-	    | ((write            & 0x1)    << 16)
-	    | ((regno            & 0xFFFF) <<  0));
+    return ((  ((uint32_t) DM_COMMAND_CMDTYPE_ACCESS_REG) << 24)
+	    | ((((uint32_t) size)             & 0x7)      << 20)
+	    | ((((uint32_t) aarpostincrement) & 0x1)      << 19)
+	    | ((((uint32_t) postexec)         & 0x1)      << 18)
+	    | ((((uint32_t) transfer)         & 0x1)      << 17)
+	    | ((((uint32_t) write)            & 0x1)      << 16)
+	    | ((((uint32_t) regno)            & 0xFFFF)   <<  0));
 }
 
 DM_command_cmdtype         fn_command_cmdtype         (uint32_t dm_word) { return ((dm_word >> 24) & 0xFF); }
@@ -416,23 +417,23 @@ uint32_t fn_mk_sbcs (bool        sbbusyerror,
 		     bool        sbreadondata,
 		     DM_sberror  sberror)
 {
-    return ((  (1               & 0x7)  << 29)    // R        sbversion
-	    | ((sbbusyerror     & 0x1)  << 22)    // R/W1C
-	    | ((0               & 0x1)  << 21)    // R        sbbusy
-	    | ((sbreadonaddr    & 0x1)  << 20)    // R/W
-	    | ((sbaccess        & 0x7)  << 17)    // R/W
-	    | ((sbautoincrement & 0x1)  << 16)    // R/W
-	    | ((sbreadondata    & 0x1)  << 15)    // R/W
-	    | ((sberror         & 0x7)  << 12)    // R/W1C
-	    | ((0               & 0x7F) << 5)     // R        sbasize
-	    | ((0               & 0x1F) << 4)     // R        sbaccess128
-	    | ((0               & 0x1F) << 3)     // R        sbaccess64
-	    | ((0               & 0x1F) << 2)     // R        sbaccess32
-	    | ((0               & 0x1F) << 1)     // R        sbaccess16
-	    | ((0               & 0x1F) << 0));   // R        sbaccess8
+    return ((  (((uint32_t) 1)               & 0x7)  << 29)    // R        sbversion
+	    | ((((uint32_t) sbbusyerror)     & 0x1)  << 22)    // R/W1C
+	    | ((((uint32_t) 0)               & 0x1)  << 21)    // R        sbbusy
+	    | ((((uint32_t) sbreadonaddr)    & 0x1)  << 20)    // R/W
+	    | ((((uint32_t) sbaccess)        & 0x7)  << 17)    // R/W
+	    | ((((uint32_t) sbautoincrement) & 0x1)  << 16)    // R/W
+	    | ((((uint32_t) sbreadondata)    & 0x1)  << 15)    // R/W
+	    | ((((uint32_t) sberror)         & 0x7)  << 12)    // R/W1C
+	    | ((((uint32_t) 0)               & 0x7F) << 5)     // R        sbasize
+	    | ((((uint32_t) 0)               & 0x1F) << 4)     // R        sbaccess128
+	    | ((((uint32_t) 0)               & 0x1F) << 3)     // R        sbaccess64
+	    | ((((uint32_t) 0)               & 0x1F) << 2)     // R        sbaccess32
+	    | ((((uint32_t) 0)               & 0x1F) << 1)     // R        sbaccess16
+	    | ((((uint32_t) 0)               & 0x1F) << 0));   // R        sbaccess8
 }
 
-uint8_t     fn_sbcs_sbversion       (uint32_t dm_word) { return ((dm_word >> 29) & 0x7); }
+uint8_t     fn_sbcs_sbversion       (uint32_t dm_word) { return (uint8_t) ((dm_word >> 29) & 0x7); }
 bool        fn_sbcs_sbbusyerror     (uint32_t dm_word) { return ((dm_word >> 22) & 0x1); }
 bool        fn_sbcs_sbbusy          (uint32_t dm_word) { return ((dm_word >> 21) & 0x1); }
 bool        fn_sbcs_sbreadonaddr    (uint32_t dm_word) { return ((dm_word >> 20) & 0x1); }
@@ -440,7 +441,7 @@ DM_sbaccess fn_sbcs_sbaccess        (uint32_t dm_word) { return ((dm_word >> 17)
 bool        fn_sbcs_sbautoincrement (uint32_t dm_word) { return ((dm_word >> 16) & 0x1); }
 bool        fn_sbcs_sbreadondata    (uint32_t dm_word) { return ((dm_word >> 15) & 0x1); }
 DM_sberror  fn_sbcs_sberror         (uint32_t dm_word) { return ((dm_word >> 12) & 0x7); }
-uint8_t     fn_sbcs_sbasize         (uint32_t dm_word) { return ((dm_word >> 5) & 0x7F); }
+uint8_t     fn_sbcs_sbasize         (uint32_t dm_word) { return (uint8_t) ((dm_word >> 5) & 0x7F); }
 bool        fn_sbcs_sbaccess128     (uint32_t dm_word) { return ((dm_word >> 4) & 0x1);  }
 bool        fn_sbcs_sbaccess64      (uint32_t dm_word) { return ((dm_word >> 3) & 0x1);  }
 bool        fn_sbcs_sbaccess32      (uint32_t dm_word) { return ((dm_word >> 2) & 0x1);  }
@@ -512,18 +513,18 @@ uint32_t fn_mk_dcsr (DM_DCSR_XDebugVer xdebugver,
 		     bool              step,
 		     DM_DCSR_PRV       prv)
 {
-    return ((  (xdebugver & 0xF) << 28)
-	    | ((ebreakm   & 0x1) << 15)
-	    | ((ebreaks   & 0x1) << 13)
-	    | ((ebreaku   & 0x1) << 12)
-	    | ((stepie    & 0x1) << 11)
-	    | ((stopcount & 0x1) << 10)
-	    | ((stoptime  & 0x1) <<  9)
-	    | ((cause     & 0x7) <<  6)
-	    | ((mprven    & 0x1) <<  4)
-	    | ((nmip      & 0x1) <<  3)
-	    | ((step      & 0x1) <<  2)
-	    | ((prv       & 0x3) <<  0));
+    return ((  (((uint32_t) xdebugver) & 0xF) << 28)
+	    | ((((uint32_t) ebreakm)   & 0x1) << 15)
+	    | ((((uint32_t) ebreaks)   & 0x1) << 13)
+	    | ((((uint32_t) ebreaku)   & 0x1) << 12)
+	    | ((((uint32_t) stepie)    & 0x1) << 11)
+	    | ((((uint32_t) stopcount) & 0x1) << 10)
+	    | ((((uint32_t) stoptime)  & 0x1) <<  9)
+	    | ((((uint32_t) cause)     & 0x7) <<  6)
+	    | ((((uint32_t) mprven)    & 0x1) <<  4)
+	    | ((((uint32_t) nmip)      & 0x1) <<  3)
+	    | ((((uint32_t) step)      & 0x1) <<  2)
+	    | ((((uint32_t) prv)       & 0x3) <<  0));
 }
 
 DM_DCSR_XDebugVer fn_dcsr_xdebugver (uint32_t dm_word) { return ((dm_word >> 28) & 0xF); }
@@ -543,15 +544,15 @@ void fprint_DM_DCSR_Cause (FILE *fp, char *pre, DM_DCSR_Cause  cause, char *post
 {
     fprintf (fp, "%s", pre);
     switch (cause) {
-    DM_DCSR_CAUSE_RESERVED0:  fprintf (fp, "CAUSE_RESERVED0");
-    DM_DCSR_CAUSE_EBREAK:     fprintf (fp, "CAUSE_EBREAK");
-    DM_DCSR_CAUSE_TRIGGER:    fprintf (fp, "CAUSE_TRIGGER");
-    DM_DCSR_CAUSE_HALTREQ:    fprintf (fp, "CAUSE_HALTREQ");
-    DM_DCSR_CAUSE_STEP:       fprintf (fp, "CAUSE_STEP");
-    DM_DCSR_CAUSE_RESERVED5:  fprintf (fp, "CAUSE_RESERVED5");
-    DM_DCSR_CAUSE_RESERVED6:  fprintf (fp, "CAUSE_RESERVED6");
-    DM_DCSR_CAUSE_RESERVED7:  fprintf (fp, "CAUSE_RESERVED7");
-    default:                  fprintf (fp, "CAUSE %0d", cause);
+    case DM_DCSR_CAUSE_RESERVED0:  fprintf (fp, "CAUSE_RESERVED0");  break;
+    case DM_DCSR_CAUSE_EBREAK:     fprintf (fp, "CAUSE_EBREAK");     break;
+    case DM_DCSR_CAUSE_TRIGGER:    fprintf (fp, "CAUSE_TRIGGER");    break;
+    case DM_DCSR_CAUSE_HALTREQ:    fprintf (fp, "CAUSE_HALTREQ");    break;
+    case DM_DCSR_CAUSE_STEP:       fprintf (fp, "CAUSE_STEP");       break;
+    case DM_DCSR_CAUSE_RESERVED5:  fprintf (fp, "CAUSE_RESERVED5");  break;
+    case DM_DCSR_CAUSE_RESERVED6:  fprintf (fp, "CAUSE_RESERVED6");  break;
+    case DM_DCSR_CAUSE_RESERVED7:  fprintf (fp, "CAUSE_RESERVED7");  break;
+    default:                       fprintf (fp, "CAUSE %0d", cause); break;
     }
     fprintf (fp, "%s", post);
 }

--- a/src/RVDM.c
+++ b/src/RVDM.c
@@ -29,22 +29,6 @@
 #include  "RVDM.h"
 
 // ================================================================
-// DMI interface (gdbstub invokes these functions)
-// These should be filled in with the appropriate mechanisms that
-// perform the actual DMI read/write on the RISC-V Debug module.
-
-void dmi_write (uint16_t addr, uint32_t data)
-{
-    fprintf (stderr, "RVDM.c: dmi_write(): Not yet implemented\n");
-}
-
-uint32_t  dmi_read  (uint16_t addr)
-{
-    fprintf (stderr, "RVDM.c: dmi_read(): Not yet implemented\n");
-    return 0;
-}
-
-// ================================================================
 // Debug Module address map
 
 // ----------------

--- a/src/RVDM.h
+++ b/src/RVDM.h
@@ -15,14 +15,6 @@
 //    Tue Oct 2 23:17:49 2018 -0700
 
 // ================================================================
-// DMI interface (gdbstub invokes these functions)
-// These should be filled in with the appropriate mechanisms that
-// perform the actual DMI read/write on the RISC-V Debug module.
-
-extern void      dmi_write (uint16_t addr, uint32_t data);
-extern uint32_t  dmi_read  (uint16_t addr);
-
-// ================================================================
 // Debug Module address map
 
 // ----------------

--- a/src/gdbstub.c
+++ b/src/gdbstub.c
@@ -1,0 +1,220 @@
+// Copyright (c) 2020 Bluespec, Inc. All Rights Reserved
+// Author: Rishiyur Nikhil
+//
+// ================================================================
+// C lib includes
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <string.h>
+#include <ctype.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <pthread.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+
+// ----------------
+// Local includes
+
+#include "gdbstub.h"
+#include "gdbstub_fe.h"
+
+//================================================================
+// gdbstub globals
+
+static Gdbstub_FE_Params gdbstub_params;
+static pthread_t         gdbstub_thread;
+static int               gdbstub_stop_pipe [2];
+
+// ================================================================
+// Common helper to set up pipe and thread.
+
+static
+void gdbstub_start_common (FILE *logfile, void *(*start_routine) (void *))
+{
+    pipe (gdbstub_stop_pipe);
+    fcntl (gdbstub_stop_pipe [1], F_SETFL, O_NONBLOCK);
+
+    gdbstub_params.logfile = logfile;
+    gdbstub_params.stop_fd = gdbstub_stop_pipe [0];
+    gdbstub_params.autoclose_logfile_stop_fd = true;
+
+    pthread_create (& gdbstub_thread, NULL, start_routine, & gdbstub_params);
+    pthread_setname_np (gdbstub_thread, "gdbstub");
+}
+
+// ================================================================
+// Entry point when listening on a TCP socket. Tight loop around
+// accept(2) and main_gdbstub, whilst checking stop_fd.
+
+static
+void *main_gdbstub_accept (void *arg)
+{
+    Gdbstub_FE_Params *params = (Gdbstub_FE_Params *) arg;
+    FILE *logfile = params->logfile;
+    int   sockfd  = params->gdb_fd;
+    int   stop_fd = params->stop_fd;
+    bool  autoclose_logfile_stop_fd = params->autoclose_logfile_stop_fd;
+
+    // Keep files open across all sessions; we manually close below.
+    params->autoclose_logfile_stop_fd = false;
+
+    while (true) {
+	fd_set rfds, wfds, efds;
+
+	FD_ZERO(&rfds);
+	FD_ZERO(&wfds);
+	FD_ZERO(&efds);
+
+	FD_SET(sockfd, &rfds);
+	int fd_max = sockfd;
+	if (stop_fd > 0) {
+	    FD_SET(stop_fd, &rfds);
+	    if (stop_fd > fd_max) {
+		fd_max = stop_fd;
+	    }
+	}
+
+	if (select (fd_max + 1, &rfds, &wfds, &efds, NULL) > 0) {
+	    if (stop_fd >= 0 && FD_ISSET(stop_fd, &rfds)) {
+		break;
+	    }
+
+	    struct sockaddr_in sa;
+	    socklen_t salen = sizeof (sa);
+	    int gdb_fd = accept (sockfd, (struct sockaddr *) (& sa), & salen);
+	    if (gdb_fd < 0) {
+		if (logfile) {
+		    fprintf (logfile, "ERROR: gdbstub.main_gdbstub_accept: Failed to accept connection: %s\n", strerror (errno));
+		}
+		continue;
+	    }
+
+	    if (logfile) {
+		char buf[INET_ADDRSTRLEN];
+		const char *str = inet_ntop (AF_INET, & sa.sin_addr, buf, sizeof (buf));
+		if (str == NULL) {
+		    str = "(unknown)";
+		}
+		fprintf (logfile, "gdbstub.main_gdbstub_accept: Accepted connection from %s:%u\n", str, ntohs (sa.sin_port));
+	    }
+
+	    params->gdb_fd = gdb_fd;
+	    main_gdbstub (params);
+	}
+    }
+
+    if (autoclose_logfile_stop_fd) {
+	if (logfile) {
+	    fclose (logfile);
+	}
+	if (stop_fd >= 0) {
+	    close (stop_fd);
+	}
+    }
+    close (sockfd);
+    return NULL;
+}
+
+// ================================================================
+// Spawn a new thread for main_gdbstub with a pipe set up for later
+// stopping it.
+
+void gdbstub_start_fd (FILE *logfile, int gdb_fd)
+{
+    gdbstub_params.gdb_fd = gdb_fd;
+    gdbstub_start_common (logfile, main_gdbstub);
+}
+
+// ================================================================
+// Spawn a new thread listening for sockets which are then used to
+// call main_gdbstub, with a pipe set up for later stopping it.
+// returns the port bound to (useful if the provided port is 0), or
+// -1 on error.
+
+int gdbstub_start_tcp (FILE *logfile, unsigned short port)
+{
+    int sockfd, err;
+    struct sockaddr_in sa;
+    socklen_t salen;
+
+    sockfd = socket (PF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (sockfd < 0) {
+	fprintf (stderr, "ERROR: Failed to open socket: %s\n", strerror (errno));
+	return sockfd;
+    }
+
+    int yes = 1;
+    err = setsockopt (sockfd, SOL_SOCKET, SO_REUSEADDR, & yes, sizeof (yes));
+    if (err < 0) {
+	fprintf (stderr, "ERROR: Failed to set SO_REUSEADDR: %s\n", strerror (errno));
+	close (sockfd);
+	return err;
+    }
+
+    salen = sizeof (sa);
+    memset (&sa, 0, salen);
+    sa.sin_family = AF_INET;
+    sa.sin_port = htons (port);
+    sa.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
+    err = bind (sockfd, (struct sockaddr *) (& sa), salen);
+    if (err < 0) {
+	fprintf (stderr, "ERROR: Failed to bind socket: %s\n", strerror (errno));
+	close (sockfd);
+	return err;
+    }
+
+    err = listen (sockfd, 1);
+    if (err < 0) {
+	fprintf (stderr, "ERROR: Failed to listen on socket: %s\n", strerror (errno));
+	close (sockfd);
+	return err;
+    }
+
+    err = getsockname (sockfd, (struct sockaddr *) (& sa), & salen);
+    if (err < 0) {
+	fprintf (stderr, "ERROR: Failed to get bound socket address: %s\n", strerror (errno));
+	close (sockfd);
+	return err;
+    }
+    else if (salen != sizeof (sa)) {
+	fprintf (stderr, "ERROR: Bad address length; got %zu, expected %zu\n", (size_t) salen, sizeof (sa));
+	close (sockfd);
+	return -1;
+    }
+
+    gdbstub_params.gdb_fd = sockfd;
+    gdbstub_start_common (logfile, main_gdbstub_accept);
+
+    return ntohs (sa.sin_port);
+}
+
+// ================================================================
+// Stop the gdbstub thread.
+
+void gdbstub_stop (void)
+{
+    char dummy = 'X';
+    write (gdbstub_stop_pipe [1], & dummy, sizeof (dummy));
+    close (gdbstub_stop_pipe [1]);
+}
+
+// ================================================================
+// Wait for the gdbstub thread to exit.
+
+void gdbstub_join (void)
+{
+    pthread_join (gdbstub_thread, NULL);
+}
+
+// ================================================================

--- a/src/gdbstub.h
+++ b/src/gdbstub.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 Bluespec, Inc. All Rights Reserved
+// Author: Rishiyur Nikhil
+//
+// ================================================================
+
+#pragma once
+
+// ****************************************************************
+// ****************************************************************
+// HIGH LEVEL API (called from the platform-specific top-level code)
+// ****************************************************************
+// ****************************************************************
+
+// ================================================================
+// Spawn a new thread for main_gdbstub with a pipe set up for later
+// stopping it.
+
+extern
+void gdbstub_start_fd (FILE *logfile, int gdb_fd);
+
+// ================================================================
+// Spawn a new thread listening for sockets which are then used to
+// call main_gdbstub, with a pipe set up for later stopping it.
+// Returns the port bound to (useful if the provided port is 0), or
+// -1 on error
+
+extern
+int gdbstub_start_tcp (FILE *logfile, unsigned short port);
+
+// ================================================================
+// Stop the gdbstub thread.
+
+extern
+void gdbstub_stop (void);
+
+// ================================================================
+// Wait for the gdbstub thread to exit.
+
+extern
+void gdbstub_join (void);
+
+// ================================================================

--- a/src/gdbstub_be.c
+++ b/src/gdbstub_be.c
@@ -782,6 +782,16 @@ uint32_t gdbstub_be_verbosity (uint32_t n)
 
 // Note: the ELF file specifies XLEN; we record it here in gdbstub_be_xlen
 
+#ifdef GDBSTUB_NO_ELF_LOAD
+uint32_t gdbstub_be_elf_load (const char *elf_filename)
+{
+    if (logfile_fp != NULL) {
+	fprintf (logfile_fp, "gdbstub_be_elf_load compiled out; returning error\n");
+    }
+
+    return status_err;
+}
+#else
 uint32_t gdbstub_be_elf_load (const char *elf_filename)
 {
     struct timespec timespec1, timespec2;
@@ -844,6 +854,7 @@ uint32_t gdbstub_be_elf_load (const char *elf_filename)
     fprintf (stdout,     "    ELF file loaded\n");
     return status;
 }
+#endif
 
 // ================================================================
 // Continue the HW execution at given PC

--- a/src/gdbstub_be.c
+++ b/src/gdbstub_be.c
@@ -1155,7 +1155,7 @@ int32_t  gdbstub_be_get_stop_reason (const uint8_t xlen, uint8_t *p_stop_reason)
     }
 
     *p_stop_reason = cause;
-    return status_ok;
+    return 0;
 }
 
 // ================================================================

--- a/src/gdbstub_be.c
+++ b/src/gdbstub_be.c
@@ -50,6 +50,8 @@
 
 static int verbosity = 1;
 
+static bool in_elf_load = false;
+
 static bool initialized = false;
 
 static FILE *logfile_fp = NULL;
@@ -834,10 +836,12 @@ uint32_t gdbstub_be_elf_load (const char *elf_filename)
     // Write ELF file contents to memory
     // Note: this could be done using DMA
     clock_gettime (CLOCK_REALTIME, & timespec1);
+    in_elf_load = true;
     uint32_t status = gdbstub_be_mem_write (gdbstub_be_xlen,
 					    features.min_addr,
 					    & (features.mem_buf [features.min_addr]),
 					    n_bytes);
+    in_elf_load = false;
     clock_gettime (CLOCK_REALTIME, & timespec2);
     uint64_t time1 = ((uint64_t) timespec1.tv_sec) * 1000000000 + ((uint64_t) timespec1.tv_nsec);
     uint64_t time2 = ((uint64_t) timespec2.tv_sec) * 1000000000 + ((uint64_t) timespec2.tv_nsec);
@@ -1878,7 +1882,7 @@ uint32_t  gdbstub_be_mem_write (const uint8_t   xlen,
 	    }
 
 	// Show progress every 1 MB
-	if ((addr4 & 0xFFFFF) == 0)
+	if (in_elf_load && ((addr4 & 0xFFFFF) == 0))
 	    fprintf (stdout,
 		     "    ... mem [0x%08" PRIx64 "] <= 0x%08x\n",
 		     addr4, x);

--- a/src/gdbstub_be.c
+++ b/src/gdbstub_be.c
@@ -30,6 +30,7 @@
 
 #include "RVDM.h"
 #include "gdbstub_be.h"
+#include "gdbstub_dmi.h"
 #include "Elf_read.h"
 
 // ****************************************************************

--- a/src/gdbstub_be.c
+++ b/src/gdbstub_be.c
@@ -53,6 +53,7 @@ static int verbosity = 1;
 static bool initialized = false;
 
 static FILE *logfile_fp = NULL;
+static bool autoclose_logfile = false;
 
 // ================================================================
 // Run-mode
@@ -526,12 +527,13 @@ const char *gdbstub_be_help (void)
 // ================================================================
 // Initialize gdbstub_be
 
-uint32_t  gdbstub_be_init (FILE *logfile)
+uint32_t  gdbstub_be_init (FILE *logfile, bool autoclose)
 {
     // Fill in whatever is needed to initialize
 
-    logfile_fp  = logfile;
-    initialized = true;
+    logfile_fp        = logfile;
+    autoclose_logfile = autoclose;
+    initialized       = true;
 
     return status_ok;
 }
@@ -543,7 +545,7 @@ uint32_t  gdbstub_be_final (const uint8_t xlen)
 {
     // Fill in whatever is needed as final actions
 
-    if (logfile_fp != NULL)
+    if (autoclose_logfile && (logfile_fp != NULL))
 	fclose (logfile_fp);
 
     return status_ok;

--- a/src/gdbstub_be.c
+++ b/src/gdbstub_be.c
@@ -64,7 +64,7 @@ static Run_Mode run_mode = PAUSED;
 // Timeout related variable. The -1 for CPU_TIMEOUT implies, the
 // timeout check is disabled
 static uint32_t numHaltChecks = 0;
-static uint32_t CPU_TIMEOUT = -1;
+static uint32_t CPU_TIMEOUT = (~ ((uint32_t) 0));
 
 // ================================================================
 // Poll dmstatus until ((dmstatus & mask) == value)
@@ -222,7 +222,7 @@ uint32_t  gdbstub_be_wait_for_sb_nonbusy (uint32_t  *p_sbcs)
 //           for FPR x is:    x + 0x1020
 
 static
-uint32_t gdbstub_be_reg_read (const int xlen, uint32_t dm_regnum, uint64_t *p_regval, uint8_t *p_cmderr)
+uint32_t gdbstub_be_reg_read (const uint8_t xlen, uint16_t dm_regnum, uint64_t *p_regval, uint8_t *p_cmderr)
 {
     // Assuming abstractcs.cmderr == 0 in the HW
     uint32_t abstractcs;
@@ -283,7 +283,7 @@ uint32_t gdbstub_be_reg_read (const int xlen, uint32_t dm_regnum, uint64_t *p_re
 //           for FPR x is:    x + 0x1020
 
 static
-uint32_t  gdbstub_be_reg_write (const int xlen, uint32_t dm_regnum, uint64_t regval, uint8_t *p_cmderr)
+uint32_t  gdbstub_be_reg_write (const uint8_t xlen, uint16_t dm_regnum, uint64_t regval, uint8_t *p_cmderr)
 {
     if (verbosity == 2)
 	if (logfile_fp != NULL) {
@@ -297,7 +297,7 @@ uint32_t  gdbstub_be_reg_write (const int xlen, uint32_t dm_regnum, uint64_t reg
     uint32_t abstractcs;
 
     // Write regval to dm_data0 register
-    dmi_write (dm_addr_data0, regval);
+    dmi_write (dm_addr_data0, (uint32_t) regval);
 
     if (xlen == 64) {
 	// Write upper bits of regval to dm_data1 register
@@ -334,11 +334,11 @@ uint32_t  gdbstub_be_reg_write (const int xlen, uint32_t dm_regnum, uint64_t reg
 
 static
 uint32_t  gdbstub_be_mem32_read (const char *context,
-				 const int xlen, const uint64_t addr, uint32_t *p_data)
+				 const uint8_t xlen, const uint64_t addr, uint32_t *p_data)
 {
-    uint32_t addr0  = addr;
-    uint32_t addr1  = addr >> 32;
-    int      status = 0;
+    uint32_t addr0  = (uint32_t) addr;
+    uint32_t addr1  = (uint32_t) (addr >> 32);
+    uint32_t status = 0;
 
     // Assert that the address is aligned
     if ((addr & 0x3) != 0) {
@@ -401,11 +401,11 @@ uint32_t  gdbstub_be_mem32_read (const char *context,
 
 static
 uint32_t  gdbstub_be_mem32_write (const char *context,
-				  const int xlen, const uint64_t addr, const uint32_t data)
+				  const uint8_t xlen, const uint64_t addr, const uint32_t data)
 {
-    uint32_t addr0  = addr;
-    uint32_t addr1  = addr >> 32;
-    int      status = 0;
+    uint32_t addr0  = (uint32_t) addr;
+    uint32_t addr1  = (uint32_t) (addr >> 32);
+    uint32_t status = 0;
 
     // Assert that the address is aligned
     if ((addr & 0x3) != 0) {
@@ -464,7 +464,7 @@ uint32_t  gdbstub_be_mem32_write (const char *context,
 // Amount of data written depends on verbosity.
 
 static
-void fprint_mem_data (FILE *fp,  const int  verbosity, const uint8_t *data, const int len)
+void fprint_mem_data (FILE *fp, const int verbosity, const char *data, const size_t len)
 {
     fprintf (fp, "    Data (hex):\n");
     if (verbosity == 0) {
@@ -472,8 +472,8 @@ void fprint_mem_data (FILE *fp,  const int  verbosity, const uint8_t *data, cons
 	return;
     }
 
-    int jmax = ((verbosity == 1) ? min (64, len) : len);
-    for (int j = 0; j < jmax; j++) {
+    size_t jmax = ((verbosity == 1) ? min (64, len) : len);
+    for (size_t j = 0; j < jmax; j++) {
 	if ((j & 0xF) == 0) fprintf (fp, "   ");
 	if ((j & 0x3) == 0) fprintf (fp, " ");
 
@@ -498,7 +498,7 @@ void fprint_mem_data (FILE *fp,  const int  verbosity, const uint8_t *data, cons
 // This defaults to 64 (for RV64), but can be set to 32.
 // If gdbstub_be_elf_load() is invoked, it'll be picked up from the ELF file.
 
-int gdbstub_be_xlen = 64;
+uint8_t gdbstub_be_xlen = 64;
 
 // ================================================================
 // Help
@@ -507,7 +507,7 @@ int gdbstub_be_xlen = 64;
 
 const char *gdbstub_be_help (void)
 {
-    const unsigned char *help_msg =
+    const char *help_msg =
 	"monitor help                       Print this help message\n"
 	"monitor verbosity n                Set verbosity of HW simulation to n\n"
 	"monitor xlen n                     Set XLEN to n (32 or 64 only)\n"
@@ -538,7 +538,7 @@ uint32_t  gdbstub_be_init (FILE *logfile)
 // ================================================================
 // Final actions for gdbstub_be
 
-uint32_t  gdbstub_be_final (const int xlen)
+uint32_t  gdbstub_be_final (const uint8_t xlen)
 {
     // Fill in whatever is needed as final actions
 
@@ -551,7 +551,7 @@ uint32_t  gdbstub_be_final (const int xlen)
 // ================================================================
 // Reset the Debug Module
 
-uint32_t  gdbstub_be_dm_reset (const int xlen)
+uint32_t  gdbstub_be_dm_reset (const uint8_t xlen)
 {
     if (! initialized) return status_ok;
 
@@ -633,7 +633,7 @@ uint32_t  gdbstub_be_dm_reset (const int xlen)
 // ================================================================
 // Reset the NDM (non-debug module, i.e., everything but the debug module)
 
-uint32_t  gdbstub_be_ndm_reset (const int xlen, bool haltreq)
+uint32_t  gdbstub_be_ndm_reset (const uint8_t xlen, bool haltreq)
 {
     if (! initialized) return status_ok;
 
@@ -699,7 +699,7 @@ uint32_t  gdbstub_be_ndm_reset (const int xlen, bool haltreq)
 // ================================================================
 // Reset the HART 
 
-uint32_t  gdbstub_be_hart_reset (const int xlen, bool haltreq)
+uint32_t  gdbstub_be_hart_reset (const uint8_t xlen, bool haltreq)
 {
     if (! initialized) return status_ok;
 
@@ -710,7 +710,6 @@ uint32_t  gdbstub_be_hart_reset (const int xlen, bool haltreq)
     }
 
     // Assuming abstractcs.cmderr == 0 in the HW
-    uint32_t abstractcs;
 
     // Reset the HART
     uint32_t dmcontrol = fn_mk_dmcontrol (haltreq,
@@ -741,11 +740,10 @@ uint32_t  gdbstub_be_hart_reset (const int xlen, bool haltreq)
 // ================================================================
 // Set verbosity to n in RISC-V system
 
-uint32_t gdbstub_be_verbosity (int n)
+uint32_t gdbstub_be_verbosity (uint32_t n)
 {
     if (! initialized) return status_ok;
 
-    uint32_t  status;
     if (logfile_fp != NULL) {
 	fprintf (logfile_fp,
 		 "gdbstub_be_verbosity (%0d)\n", n);
@@ -799,8 +797,8 @@ uint32_t gdbstub_be_elf_load (const char *elf_filename)
 	fprintf (logfile_fp, "    Reading ELF file\n");
 	fflush (logfile_fp);
     }
-    uint32_t status = elf_readfile (logfile_fp, elf_filename, & features);
-    if (status != status_ok) return status;
+    int ret = elf_readfile (logfile_fp, elf_filename, & features);
+    if (ret == 0) return status_err;
 
     gdbstub_be_xlen = features.bitwidth;
     if (logfile_fp != NULL) {
@@ -823,13 +821,13 @@ uint32_t gdbstub_be_elf_load (const char *elf_filename)
     // Write ELF file contents to memory
     // Note: this could be done using DMA
     clock_gettime (CLOCK_REALTIME, & timespec1);
-    status = gdbstub_be_mem_write (gdbstub_be_xlen,
-				   features.min_addr,
-				   & (features.mem_buf [features.min_addr]),
-				   n_bytes);
+    uint32_t status = gdbstub_be_mem_write (gdbstub_be_xlen,
+					    features.min_addr,
+					    & (features.mem_buf [features.min_addr]),
+					    n_bytes);
     clock_gettime (CLOCK_REALTIME, & timespec2);
-    uint64_t time1 = ((uint64_t) timespec1.tv_sec) * 1000000000 + timespec1.tv_nsec;
-    uint64_t time2 = ((uint64_t) timespec2.tv_sec) * 1000000000 + timespec2.tv_nsec;
+    uint64_t time1 = ((uint64_t) timespec1.tv_sec) * 1000000000 + ((uint64_t) timespec1.tv_nsec);
+    uint64_t time2 = ((uint64_t) timespec2.tv_sec) * 1000000000 + ((uint64_t) timespec2.tv_nsec);
     uint64_t time_delta = time2 - time1;
     uint64_t B_per_sec = (n_bytes * 1000000000) / time_delta;
 
@@ -849,21 +847,22 @@ uint32_t gdbstub_be_elf_load (const char *elf_filename)
 // ================================================================
 // Continue the HW execution at given PC
 
-uint32_t gdbstub_be_continue (const int xlen)
+uint32_t gdbstub_be_continue (const uint8_t xlen)
 {
     if (! initialized) return status_ok;
 
     // Read 'dcsr' register
-    uint64_t dcsr;
+    uint64_t dcsr64;
     uint8_t  cmderr;
 
     if (logfile_fp != NULL) {
 	fprintf (logfile_fp, "gdbstub_be_continue: read dcsr ...\n");
 	fflush (logfile_fp);
     }
-    int status = gdbstub_be_reg_read (xlen, csr_addr_dcsr, & dcsr, & cmderr);
+    uint32_t status = gdbstub_be_reg_read (xlen, csr_addr_dcsr, & dcsr64, & cmderr);
     if (status == status_err) return status_err;
 
+    uint32_t dcsr = (uint32_t) dcsr64;
     if (logfile_fp != NULL) {
 	fprint_dcsr (logfile_fp,
 		     "gdbstub_be_continue: read dcsr => ", dcsr, "\n");
@@ -936,21 +935,22 @@ uint32_t gdbstub_be_continue (const int xlen)
 // Return 0 on success
 //        n (> 0) on error, where n is an error code.
 
-uint32_t  gdbstub_be_step (const int xlen)
+uint32_t  gdbstub_be_step (const uint8_t xlen)
 {
     if (! initialized) return status_ok;
 
     // Read 'dcsr' register
-    uint64_t dcsr;
+    uint64_t dcsr64;
     uint8_t  cmderr;
 
     if (logfile_fp != NULL) {
 	fprintf (logfile_fp, "gdbstub_be_step: read dcsr ...\n");
 	fflush (logfile_fp);
     }
-    int status = gdbstub_be_reg_read (xlen, csr_addr_dcsr, & dcsr, & cmderr);
+    uint32_t status = gdbstub_be_reg_read (xlen, csr_addr_dcsr, & dcsr64, & cmderr);
     if (status == status_err) return status_err;
 
+    uint32_t dcsr = (uint32_t) dcsr64;
     if (logfile_fp != NULL) {
 	fprint_dcsr (logfile_fp,
 		     "gdbstub_be_step: read dcsr => ", dcsr, "\n");
@@ -1030,7 +1030,7 @@ uint32_t  gdbstub_be_step (const int xlen)
 // ================================================================
 // Stop the HW execution
 
-uint32_t  gdbstub_be_stop (const int xlen)
+uint32_t  gdbstub_be_stop (const uint8_t xlen)
 {
     if (! initialized) return status_ok;
 
@@ -1068,7 +1068,7 @@ uint32_t  gdbstub_be_stop (const int xlen)
 // Get stop-reason from HW
 // (HW normally stops due to GDB ^C, after a 'step', or at a breakpoint)
 
-uint32_t  gdbstub_be_get_stop_reason (const int xlen, uint8_t *p_stop_reason)
+int32_t  gdbstub_be_get_stop_reason (const uint8_t xlen, uint8_t *p_stop_reason)
 {
     if (! initialized) return status_ok;
 
@@ -1098,7 +1098,7 @@ uint32_t  gdbstub_be_get_stop_reason (const int xlen, uint8_t *p_stop_reason)
 	    }
         }
 
-        if ((CPU_TIMEOUT != -1) && (numHaltChecks >= CPU_TIMEOUT)) {
+        if (((~ CPU_TIMEOUT) != 0) && (numHaltChecks >= CPU_TIMEOUT)) {
 	    if (logfile_fp != NULL) {
 		fprintf (logfile_fp,
 			 "ERROR: gdbstub_be_get_stop_reason () => CPU TIMEOUT \n");
@@ -1125,12 +1125,13 @@ uint32_t  gdbstub_be_get_stop_reason (const int xlen, uint8_t *p_stop_reason)
 	fflush (logfile_fp);
     }
 
-    uint64_t dcsr;
+    uint64_t dcsr64;
     uint8_t  cmderr;
 
-    int status = gdbstub_be_reg_read (xlen, csr_addr_dcsr, & dcsr, & cmderr);
+    uint32_t status = gdbstub_be_reg_read (xlen, csr_addr_dcsr, & dcsr64, & cmderr);
     if (status == status_err) return -1;
 
+    uint32_t dcsr = (uint32_t) dcsr64;
     uint8_t cause = fn_dcsr_cause (dcsr);
     if (logfile_fp != NULL) {
 	fprintf (logfile_fp,
@@ -1152,7 +1153,7 @@ uint32_t  gdbstub_be_get_stop_reason (const int xlen, uint8_t *p_stop_reason)
 
 static int command_num = 0;
 
-uint32_t  gdbstub_be_start_command (const int xlen)
+uint32_t  gdbstub_be_start_command (const uint8_t xlen)
 {
     if (! initialized) return status_ok;
 
@@ -1168,7 +1169,7 @@ uint32_t  gdbstub_be_start_command (const int xlen)
 // ================================================================
 // Read a value from the PC
 
-uint32_t  gdbstub_be_PC_read (const int xlen, uint64_t *p_PC)
+uint32_t  gdbstub_be_PC_read (const uint8_t xlen, uint64_t *p_PC)
 {
     *p_PC = 0;
     if (! initialized) return status_ok;
@@ -1180,20 +1181,21 @@ uint32_t  gdbstub_be_PC_read (const int xlen, uint64_t *p_PC)
 
     // Read 'dpc' in debug module, = CSR 0X7b1
     uint8_t  cmderr;
-    int status = gdbstub_be_reg_read (xlen, csr_addr_dpc, p_PC, & cmderr);
-    if (status == status_err)
+    uint32_t status = gdbstub_be_reg_read (xlen, csr_addr_dpc, p_PC, & cmderr);
+    if (status == status_err) {
 	if (logfile_fp != NULL) {
 	    fprint_abstractcs_cmderr (logfile_fp,
 				      "    ERROR: gdbstub_be_PC_read (csr 0x7b1) => ",
 				      cmderr, "\n");
 	    fflush (logfile_fp);
 	}
-    else
+    } else {
 	if (logfile_fp != NULL) {
 	    fprintf (logfile_fp,
 		     "    gdbstub_be_PC_read (csr 0x7b1) => 0x%0" PRIx64 "\n", *p_PC);
 	    fflush (logfile_fp);
 	}
+    }
 
     return status;
 }
@@ -1201,7 +1203,7 @@ uint32_t  gdbstub_be_PC_read (const int xlen, uint64_t *p_PC)
 // ================================================================
 // Read a value from a GPR register in SoC
 
-uint32_t  gdbstub_be_GPR_read (const int xlen, uint32_t regnum, uint64_t *p_regval)
+uint32_t  gdbstub_be_GPR_read (const uint8_t xlen, uint8_t regnum, uint64_t *p_regval)
 {
     *p_regval = 0;
     if (! initialized) return status_ok;
@@ -1215,8 +1217,8 @@ uint32_t  gdbstub_be_GPR_read (const int xlen, uint32_t regnum, uint64_t *p_regv
 
     // Debug module encodes GPR x as 0x1000 + x
     uint8_t  cmderr;
-    int status = gdbstub_be_reg_read (xlen, regnum + dm_command_access_reg_regno_gpr_0,
-				      p_regval, & cmderr);
+    uint16_t hwregnum = (uint16_t) (regnum + dm_command_access_reg_regno_gpr_0);
+    uint32_t status = gdbstub_be_reg_read (xlen, hwregnum, p_regval, & cmderr);
 
     if (status == status_err) {
 	if (logfile_fp != NULL) {
@@ -1240,7 +1242,7 @@ uint32_t  gdbstub_be_GPR_read (const int xlen, uint32_t regnum, uint64_t *p_regv
 // ================================================================
 // Read a value from a FPR register in SoC
 
-uint32_t  gdbstub_be_FPR_read (const int xlen, uint32_t regnum, uint64_t *p_regval)
+uint32_t  gdbstub_be_FPR_read (const uint8_t xlen, uint8_t regnum, uint64_t *p_regval)
 {
     *p_regval = 0;
     if (! initialized) return status_ok;
@@ -1254,8 +1256,8 @@ uint32_t  gdbstub_be_FPR_read (const int xlen, uint32_t regnum, uint64_t *p_regv
 
     // Debug module encodes FPR x as 0x1020 + x
     uint8_t  cmderr;
-    int status = gdbstub_be_reg_read (xlen, regnum + dm_command_access_reg_regno_fpr_0,
-				      p_regval, & cmderr);
+    uint16_t hwregnum = (uint16_t) (regnum + dm_command_access_reg_regno_fpr_0);
+    uint32_t status = gdbstub_be_reg_read (xlen, hwregnum, p_regval, & cmderr);
 
     if (status == status_err) {
 	if (logfile_fp != NULL) {
@@ -1279,7 +1281,7 @@ uint32_t  gdbstub_be_FPR_read (const int xlen, uint32_t regnum, uint64_t *p_regv
 // ================================================================
 // Read a value from a CSR in SoC
 
-uint32_t  gdbstub_be_CSR_read (const int xlen, uint32_t regnum, uint64_t *p_regval)
+uint32_t  gdbstub_be_CSR_read (const uint8_t xlen, uint16_t regnum, uint64_t *p_regval)
 {
     *p_regval = 0;
     if (! initialized) return status_ok;
@@ -1293,8 +1295,8 @@ uint32_t  gdbstub_be_CSR_read (const int xlen, uint32_t regnum, uint64_t *p_regv
 
     // Debug module encodes CSR x as x
     uint8_t  cmderr;
-    int status = gdbstub_be_reg_read (xlen, regnum + dm_command_access_reg_regno_csr_0,
-				      p_regval, & cmderr);
+    uint16_t hwregnum = (uint16_t) (regnum + dm_command_access_reg_regno_csr_0);
+    uint32_t status = gdbstub_be_reg_read (xlen, hwregnum, p_regval, & cmderr);
 
     if (status == status_err) {
 	if (logfile_fp != NULL) {
@@ -1319,16 +1321,16 @@ uint32_t  gdbstub_be_CSR_read (const int xlen, uint32_t regnum, uint64_t *p_regv
 // ================================================================
 // Read one byte from SoC memory at address 'addr' into 'data'
 
-uint32_t  gdbstub_be_mem_read_subword (const int       xlen,
+uint32_t  gdbstub_be_mem_read_subword (const uint8_t   xlen,
 				       const uint64_t  addr,
-				       uint64_t       *data,
-				       const uint32_t  len)
+				       uint32_t       *data,
+				       const size_t    len)
 {
     if (! initialized) return status_ok;
 
     if (logfile_fp != NULL) {
 	fprintf (logfile_fp,
-		 "gdbstub_be_mem_read_subword (addr 0x%0" PRIx64 ", data, %0d)\n",
+		 "gdbstub_be_mem_read_subword (addr 0x%0" PRIx64 ", data, len %0zu)\n",
 		 addr, len);
 	fflush (logfile_fp);
     }
@@ -1361,7 +1363,7 @@ uint32_t  gdbstub_be_mem_read_subword (const int       xlen,
 	sbaccess = DM_SBACCESS_32_BIT;
     }
     else /* (len == 3) */ {
-	fprintf (stderr, "    ERROR: requested len is %0d, should be 1, 2 or 4 only\n", len);
+	fprintf (stderr, "    ERROR: requested len is %0zu, should be 1, 2 or 4 only\n", len);
 	return status_err;
     }
 
@@ -1381,14 +1383,23 @@ uint32_t  gdbstub_be_mem_read_subword (const int       xlen,
     }
     dmi_write (dm_addr_sbcs, sbcs);
 
-    // Write the address to sbaddress0 (which will start a bus read)
+    // Write address to sbaddress1/0 (which will start a bus read)
     status = gdbstub_be_wait_for_sb_nonbusy (NULL);
     if (status == status_err) return status;
+    if (xlen == 64) {
+	// Write upper 64b of address to sbaddress1
+	if (logfile_fp != NULL) {
+	    fprintf (logfile_fp, "    Write to sbaddress1: 0x%08" PRIx32 "\n", (uint32_t) (addr >> 32));
+	    fflush (logfile_fp);
+	}
+	dmi_write (dm_addr_sbaddress1, (uint32_t) (addr >> 32));
+    }
+    // Write lower 32b of the address to sbaddress0
     if (logfile_fp != NULL) {
-	fprintf (logfile_fp, "    Write to sbaddress0: 0x%0" PRIx64 "\n", addr);
+	fprintf (logfile_fp, "    Write to sbaddress0: 0x%08" PRIx32 "\n", (uint32_t) addr);
 	fflush (logfile_fp);
     }
-    dmi_write (dm_addr_sbaddress0, addr);
+    dmi_write (dm_addr_sbaddress0, (uint32_t) addr);
 
     status = gdbstub_be_wait_for_sb_nonbusy (NULL);
     if (status == status_err) return status;
@@ -1405,16 +1416,16 @@ uint32_t  gdbstub_be_mem_read_subword (const int       xlen,
 // No alignment restriction on 'addr'; no restriction on 'len'.
 // Only performs 32-bit reads on the Debug Module.
 
-uint32_t  gdbstub_be_mem_read (const int       xlen,
+uint32_t  gdbstub_be_mem_read (const uint8_t   xlen,
 			       const uint64_t  addr,
-			       uint8_t        *data,
-			       const uint32_t  len)
+			       char           *data,
+			       const size_t    len)
 {
     if (! initialized) return status_ok;
 
     if (logfile_fp != NULL) {
 	fprintf (logfile_fp,
-		 "gdbstub_be_mem_read (addr 0x%0" PRIx64 ", data, len 0x%0x)\n",
+		 "gdbstub_be_mem_read (addr 0x%0" PRIx64 ", data, len %0zu)\n",
 		 addr, len);
 	fflush (logfile_fp);
     }
@@ -1428,7 +1439,7 @@ uint32_t  gdbstub_be_mem_read (const int       xlen,
     const uint64_t addr_lim      = addr + len;
     uint64_t       addr4         = (addr & (~ addr_lsb_mask));            // 32b-aligned at/below addr
     const uint64_t addr_lim4     = ((addr_lim + 3) & (~ addr_lsb_mask));  // 32b-aligned at/below addr_lim
-    uint32_t jd                  = 0;                                     // index into data []
+    size_t         jd            = 0;                                     // index into data []
 
     // Write SBCS
     status = gdbstub_be_wait_for_sb_nonbusy (NULL);
@@ -1448,11 +1459,20 @@ uint32_t  gdbstub_be_mem_read (const int       xlen,
     // Write the initial address to sbaddress0 (which will start a bus read)
     status = gdbstub_be_wait_for_sb_nonbusy (NULL);
     if (status == status_err) return status;
+    if (xlen == 64) {
+	// Write upper 32b of address to sbaddress1
+	if (logfile_fp != NULL) {
+	    fprintf (logfile_fp, "    Write to sbaddress1: 0x%08" PRIx32 "\n", (uint32_t) (addr4 >> 32));
+	    fflush (logfile_fp);
+	}
+	dmi_write (dm_addr_sbaddress1, (uint32_t) (addr4 >> 32));
+    }
+    // Write lower 32b of the address to sbaddress0
     if (logfile_fp != NULL) {
-	fprintf (logfile_fp, "    Write to sbaddress0: 0x%0" PRIx64 "\n", addr4);
+	fprintf (logfile_fp, "    Write to sbaddress0: 0x%08" PRIx32 "\n", (uint32_t) addr4);
 	fflush (logfile_fp);
     }
-    dmi_write (dm_addr_sbaddress0, addr4);
+    dmi_write (dm_addr_sbaddress0, (uint32_t) addr4);
 
     // Repeatedly read sbdata0
     while (addr4 < addr_lim4) {
@@ -1465,13 +1485,13 @@ uint32_t  gdbstub_be_mem_read (const int       xlen,
 	if (addr4 < addr) {
 	    assert ((addr - addr4) < 4);
 	    uint8_t  *p_x    = (uint8_t *) (& x);
-	    int       offset = addr - addr4;
+	    size_t    offset = (size_t) (addr - addr4);
 	    memcpy (& (data [0]), & (p_x [offset]), 4 - offset);
 	    jd    += (4 - offset);
 	    /*
 	    if (logfile_fp != NULL) {
 	    fprintf (logfile_fp,
-                     "gdbstub_be_mem_read: addr4 0x%0" PRIx64 ", initial %0d bytes\n",
+                     "gdbstub_be_mem_read: addr4 0x%0" PRIx64 ", initial %0zu bytes\n",
 		     addr4, (4 - offset));
             }
 	    */
@@ -1515,7 +1535,7 @@ uint32_t  gdbstub_be_mem_read (const int       xlen,
 // ================================================================
 // Write a value into the RISC-V PC
 
-uint32_t  gdbstub_be_PC_write (const int xlen, uint64_t regval)
+uint32_t  gdbstub_be_PC_write (const uint8_t xlen, uint64_t regval)
 {
     if (! initialized) return status_ok;
 
@@ -1526,7 +1546,7 @@ uint32_t  gdbstub_be_PC_write (const int xlen, uint64_t regval)
 
     // Write 'dpc' in debug module, = CSR 0X7b1
     uint8_t  cmderr;
-    int status = gdbstub_be_reg_write (xlen, csr_addr_dpc, regval, & cmderr);
+    uint32_t status = gdbstub_be_reg_write (xlen, csr_addr_dpc, regval, & cmderr);
 
     if (status == status_err) {
 	if (logfile_fp != NULL) {
@@ -1550,7 +1570,7 @@ uint32_t  gdbstub_be_PC_write (const int xlen, uint64_t regval)
 // ================================================================
 // Write a value into a RISC-V GPR register
 
-uint32_t  gdbstub_be_GPR_write (const int xlen, uint32_t regnum, uint64_t regval)
+uint32_t  gdbstub_be_GPR_write (const uint8_t xlen, uint8_t regnum, uint64_t regval)
 {
     if (! initialized) return status_ok;
 
@@ -1565,7 +1585,8 @@ uint32_t  gdbstub_be_GPR_write (const int xlen, uint32_t regnum, uint64_t regval
 
     // Debug module encodes GPR x as 0x1000 + x
     uint8_t  cmderr;
-    int status = gdbstub_be_reg_write (xlen, regnum + dm_command_access_reg_regno_gpr_0, regval, & cmderr);
+    uint16_t hwregnum = (uint16_t) (regnum + dm_command_access_reg_regno_gpr_0);
+    uint32_t status = gdbstub_be_reg_write (xlen, hwregnum, regval, & cmderr);
 
     if (status == status_err) {
 	if (logfile_fp != NULL) {
@@ -1582,7 +1603,7 @@ uint32_t  gdbstub_be_GPR_write (const int xlen, uint32_t regnum, uint64_t regval
 // ================================================================
 // Write a value into a RISC-V FPR register
 
-uint32_t  gdbstub_be_FPR_write (const int xlen, uint32_t regnum, uint64_t regval)
+uint32_t  gdbstub_be_FPR_write (const uint8_t xlen, uint8_t regnum, uint64_t regval)
 {
     if (! initialized) return status_ok;
 
@@ -1597,7 +1618,8 @@ uint32_t  gdbstub_be_FPR_write (const int xlen, uint32_t regnum, uint64_t regval
 
     // Debug module encodes FPR x as 0x1000 + x
     uint8_t  cmderr;
-    int status = gdbstub_be_reg_write (xlen, regnum + dm_command_access_reg_regno_fpr_0, regval, & cmderr);
+    uint16_t hwregnum = (uint16_t) (regnum + dm_command_access_reg_regno_fpr_0);
+    uint32_t status = gdbstub_be_reg_write (xlen, hwregnum, regval, & cmderr);
 
     if (status == status_err) {
 	if (logfile_fp != NULL) {
@@ -1615,7 +1637,7 @@ uint32_t  gdbstub_be_FPR_write (const int xlen, uint32_t regnum, uint64_t regval
 // ================================================================
 // Write a value into a RISC-V CSR register
 
-uint32_t  gdbstub_be_CSR_write (const int xlen, uint32_t regnum, uint64_t regval)
+uint32_t  gdbstub_be_CSR_write (const uint8_t xlen, uint16_t regnum, uint64_t regval)
 {
     if (! initialized) return status_ok;
 
@@ -1630,7 +1652,8 @@ uint32_t  gdbstub_be_CSR_write (const int xlen, uint32_t regnum, uint64_t regval
 
     // Debug module encodes CSR x as x
     uint8_t  cmderr;
-    int status = gdbstub_be_reg_write (xlen, regnum + dm_command_access_reg_regno_csr_0, regval, & cmderr);
+    uint16_t hwregnum = (uint16_t) (regnum + dm_command_access_reg_regno_csr_0);
+    uint32_t status = gdbstub_be_reg_write (xlen, hwregnum, regval, & cmderr);
 
     if (status == status_err) {
 	if (logfile_fp != NULL) {
@@ -1649,22 +1672,22 @@ uint32_t  gdbstub_be_CSR_write (const int xlen, uint32_t regnum, uint64_t regval
 // Write 'len' bytes of 'data' into RISC-V system memory, starting at address 'addr'
 // where 'len' is 1, 2 or 4 only, and addr is aligned.
 
-uint32_t  gdbstub_be_mem_write_subword (const int       xlen,
+uint32_t  gdbstub_be_mem_write_subword (const uint8_t   xlen,
 					const uint64_t  addr,
-					const uint64_t  data,
-					const uint32_t  len)
+					const uint32_t  data,
+					const size_t    len)
 {
     if (! initialized) return status_ok;
 
     if (logfile_fp != NULL) {
 	fprintf (logfile_fp,
-		 "gdbstub_be_mem_write_subword (addr 0x%0" PRIx64 ", data 0x%0" PRIx64 ", len %0d)\n",
+		 "gdbstub_be_mem_write_subword (addr 0x%0" PRIx64 ", data 0x%0" PRIx32 ", len %0zu)\n",
 		 addr, data, len);
 	fflush (logfile_fp);
     }
 
     if ((len != 1) && (len != 2) && (len != 4)) {
-	fprintf (stderr, "    ERROR: len (%0d) should be 1, 2 or 4 only\n", len);
+	fprintf (stderr, "    ERROR: len (%0zu) should be 1, 2 or 4 only\n", len);
 	return status_err;
     }
     
@@ -1708,18 +1731,19 @@ uint32_t  gdbstub_be_mem_write_subword (const int       xlen,
     status = gdbstub_be_wait_for_sb_nonbusy (NULL);
     if (status == status_err) return status;
     if (xlen == 64) {
-	// Write upper 64b of address to sbaddress1
+	// Write upper 32b of address to sbaddress1
 	if (logfile_fp != NULL) {
-	    fprintf (logfile_fp, "    Write to sbaddress1: 0x%08" PRIx64 "\n", (addr >> 32));
+	    fprintf (logfile_fp, "    Write to sbaddress1: 0x%08" PRIx32 "\n", (uint32_t) (addr >> 32));
 	    fflush (logfile_fp);
 	}
-	dmi_write (dm_addr_sbaddress1, (addr >> 32));
+	dmi_write (dm_addr_sbaddress1, (uint32_t) (addr >> 32));
     }
-    // Write lower 64b of the address to sbaddress0
+    // Write lower 32b of the address to sbaddress0
     if (logfile_fp != NULL) {
-	fprintf (logfile_fp, "    Write to sbaddress0: 0x%08" PRIx64 "\n", addr);
+	fprintf (logfile_fp, "    Write to sbaddress0: 0x%08" PRIx32 "\n", (uint32_t) addr);
+	fflush (logfile_fp);
     }
-    dmi_write (dm_addr_sbaddress0, addr);
+    dmi_write (dm_addr_sbaddress0, (uint32_t) addr);
 
     // Write the data
     dmi_write (dm_addr_sbdata0, data);
@@ -1732,16 +1756,16 @@ uint32_t  gdbstub_be_mem_write_subword (const int       xlen,
 // Write 'len' bytes of 'data' into RISC-V system memory, starting at address 'addr'
 // Only performs 32-bit writes on the Debug Module.
 
-uint32_t  gdbstub_be_mem_write (const int       xlen,
+uint32_t  gdbstub_be_mem_write (const uint8_t   xlen,
 				const uint64_t  addr,
-				const uint8_t  *data,
-				const uint32_t  len)
+				const char     *data,
+				const size_t    len)
 {
     if (! initialized) return status_ok;
 
     if (logfile_fp != NULL) {
 	fprintf (logfile_fp,
-		 "gdbstub_be_mem_write (addr 0x%0" PRIx64 ", data, len 0x%0x)\n",
+		 "gdbstub_be_mem_write (addr 0x%0" PRIx64 ", data, len %0zu)\n",
 		 addr, len);
 	fflush (logfile_fp);
     }
@@ -1758,9 +1782,9 @@ uint32_t  gdbstub_be_mem_write (const int       xlen,
     uint32_t status = 0;
 
     const uint64_t addr_lim  = addr + len;
-    uint64_t       addr4     = (addr & (~ 0x3));        // 32b-aligned at/below addr
-    const uint64_t addr_lim4 = (addr_lim & (~ 0x3));    // 32b-aligned at/below addr_lim
-    uint32_t jd              = 0;                       // index into data []
+    uint64_t       addr4     = (addr & (~ ((uint64_t) 0x3)));        // 32b-aligned at/below addr
+    const uint64_t addr_lim4 = (addr_lim & (~ ((uint64_t) 0x3)));    // 32b-aligned at/below addr_lim
+    size_t         jd        = 0;                       // index into data []
 
     // ----------------
     // Write any initial  unaligned bytes by doing a 32b read-modify-write
@@ -1770,7 +1794,7 @@ uint32_t  gdbstub_be_mem_write (const int       xlen,
 	status = gdbstub_be_mem32_read ("gdbstub_be_mem32_read", xlen, addr4, & x);
 	if (status != status_ok) return status;
 	uint8_t  *p_x    = (uint8_t *) (& x);
-	int       offset = addr - addr4;
+	size_t    offset = (size_t) (addr - addr4);
 	memcpy (& (p_x [offset]), & (data [0]), 4 - offset);
 	status = gdbstub_be_mem32_write ("gdbstub_be_mem_write", xlen, addr4, x);
 	if (status != status_ok) return status;
@@ -1778,7 +1802,7 @@ uint32_t  gdbstub_be_mem_write (const int       xlen,
 	addr4 += 4;
 	jd    += (4 - offset);
 	if (logfile_fp != NULL) {
-	    fprintf (logfile_fp, "    Write initial sub-word (%0d bytes)\n", (4 - offset));
+	    fprintf (logfile_fp, "    Write initial sub-word (%0zu bytes)\n", (4 - offset));
 	    fflush (logfile_fp);
 	}
     }
@@ -1813,17 +1837,17 @@ uint32_t  gdbstub_be_mem_write (const int       xlen,
     if (xlen == 64) {
 	// Write upper 64b of address to sbaddress1
 	if (logfile_fp != NULL) {
-	    fprintf (logfile_fp, "    Write to sbaddress1: 0x%08" PRIx64 "\n", (addr4 >> 32));
+	    fprintf (logfile_fp, "    Write to sbaddress1: 0x%08" PRIx32 "\n", (uint32_t) (addr4 >> 32));
 	    fflush (logfile_fp);
 	}
-	dmi_write (dm_addr_sbaddress1, (addr4 >> 32));
+	dmi_write (dm_addr_sbaddress1, (uint32_t) (addr4 >> 32));
     }
     // Write lower 64b of the address to sbaddress0
     if (logfile_fp != NULL) {
-	fprintf (logfile_fp, "    Write to sbaddress0: 0x%08" PRIx64 "\n", addr4);
+	fprintf (logfile_fp, "    Write to sbaddress0: 0x%08" PRIx32 "\n", (uint32_t) addr4);
 	fflush (logfile_fp);
     }
-    dmi_write (dm_addr_sbaddress0, addr4);
+    dmi_write (dm_addr_sbaddress0, (uint32_t) addr4);
 
     while (addr4 < addr_lim4) {
 	// status = gdbstub_be_wait_for_sb_nonbusy (NULL);
@@ -1858,11 +1882,11 @@ uint32_t  gdbstub_be_mem_write (const int       xlen,
 	uint32_t x;
 	gdbstub_be_mem32_read ("gdbstub_be_mem_write", xlen, addr4, & x);
 	uint8_t  *p_x    = (uint8_t *) (& x);
-	int       n      = (addr_lim - addr4);
+	size_t    n      = (size_t) (addr_lim - addr4);
 	memcpy (p_x, & (data [jd]), n);
 	gdbstub_be_mem32_write ("gdbstub_be_mem_write", xlen, addr4, x);
 	if (logfile_fp != NULL) {
-	    fprintf (logfile_fp, "    Write final sub-word (%0d bytes)\n", n);
+	    fprintf (logfile_fp, "    Write final sub-word (%0zu bytes)\n", n);
 	    fflush (logfile_fp);
 	}
     }
@@ -1901,7 +1925,7 @@ uint32_t  gdbstub_be_mem_write (const int       xlen,
 // ================================================================
 // Raw DMI read
 
-uint32_t  gdbstub_be_dmi_read (const uint32_t  dmi_addr, uint64_t *p_data)
+uint32_t  gdbstub_be_dmi_read (const uint16_t  dmi_addr, uint32_t *p_data)
 {
     *p_data = 0;
     if (! initialized) return status_ok;
@@ -1920,13 +1944,13 @@ uint32_t  gdbstub_be_dmi_read (const uint32_t  dmi_addr, uint64_t *p_data)
 // ================================================================
 // Raw DMI write
 
-uint32_t  gdbstub_be_dmi_write (const uint32_t  dmi_addr, uint64_t  dmi_data)
+uint32_t  gdbstub_be_dmi_write (const uint16_t  dmi_addr, uint32_t  dmi_data)
 {
     if (! initialized) return status_ok;
 
     if (logfile_fp != NULL) {
 	fprintf (logfile_fp,
-		 "gdbstub_be_dmi_write (dmi 0x%0x, data 0x%0" PRIx64 ")\n",
+		 "gdbstub_be_dmi_write (dmi 0x%0x, data 0x%0" PRIx32 ")\n",
 		 dmi_addr, dmi_data);
 	fflush (logfile_fp);
     }

--- a/src/gdbstub_be.c
+++ b/src/gdbstub_be.c
@@ -1150,7 +1150,7 @@ int32_t  gdbstub_be_get_stop_reason (const uint8_t xlen, uint8_t *p_stop_reason)
     if (status == status_err) return -1;
 
     uint32_t dcsr = (uint32_t) dcsr64;
-    uint8_t cause = fn_dcsr_cause (dcsr);
+    DM_DCSR_Cause cause = fn_dcsr_cause (dcsr);
     if (logfile_fp != NULL) {
 	fprintf (logfile_fp,
 		 "    gdbstub_be_get_stop_reason () => halted; dcsr.cause = %0d\n",
@@ -1158,7 +1158,28 @@ int32_t  gdbstub_be_get_stop_reason (const uint8_t xlen, uint8_t *p_stop_reason)
 	fflush (logfile_fp);
     }
 
-    *p_stop_reason = cause;
+    switch (cause) {
+    case DM_DCSR_CAUSE_EBREAK:
+    case DM_DCSR_CAUSE_TRIGGER:
+	// SIGTRAP
+	*p_stop_reason = 0x05;
+	break;
+    case DM_DCSR_CAUSE_HALTREQ:
+	// SIGINT
+	*p_stop_reason = 0x02;
+	break;
+    case DM_DCSR_CAUSE_STEP:
+	// SIGTRAP
+	*p_stop_reason = 0x05;
+	break;
+    default:
+	*p_stop_reason = 0;
+	if (logfile_fp != NULL) {
+	    fprintf (logfile_fp,
+		     "    gdbstub_be_get_stop_reason () => unknown\n");
+	    fflush (logfile_fp);
+	}
+    }
     return 0;
 }
 

--- a/src/gdbstub_be.h
+++ b/src/gdbstub_be.h
@@ -21,7 +21,7 @@
 // If gdbstub_be_elf_load() is invoked, it'll be picked up from the ELF file.
 
 extern
-int gdbstub_be_xlen;
+uint8_t gdbstub_be_xlen;
 
 // ================================================================
 // Help
@@ -41,33 +41,33 @@ uint32_t  gdbstub_be_init (FILE *logfile);
 // Final actions for gdbstub_be
 
 extern
-uint32_t  gdbstub_be_final (const int xlen);
+uint32_t  gdbstub_be_final (const uint8_t xlen);
 
 // ================================================================
 // Reset the Debug Module
 
 extern
-uint32_t  gdbstub_be_dm_reset (const int xlen);
+uint32_t  gdbstub_be_dm_reset (const uint8_t xlen);
 
 // ================================================================
 // Reset the NDM (non-debug module, i.e., everything but the debug module)
 // The argument indicates whether the hart is running/halted after reset
 
 extern
-uint32_t  gdbstub_be_ndm_reset (const int xlen, bool haltreq);
+uint32_t  gdbstub_be_ndm_reset (const uint8_t xlen, bool haltreq);
 
 // ================================================================
 // Reset the HART 
 // The argument indicates whether the hart is running/halted after reset
 
 extern
-uint32_t  gdbstub_be_hart_reset (const int xlen, bool haltreq);
+uint32_t  gdbstub_be_hart_reset (const uint8_t xlen, bool haltreq);
 
 // ================================================================
 // Set verbosity to n in RISC-V system
 
 extern
-uint32_t gdbstub_be_verbosity (int n);
+uint32_t gdbstub_be_verbosity (uint32_t n);
 
 // ================================================================
 // Load ELF file into RISC-V memory
@@ -79,26 +79,26 @@ uint32_t gdbstub_be_elf_load (const char *elf_filename);
 // Continue the HW execution at given PC
 
 extern
-uint32_t gdbstub_be_continue (const int xlen);
+uint32_t gdbstub_be_continue (const uint8_t xlen);
 
 // ================================================================
 // Step the HW execution at given PC
 
 extern
-uint32_t  gdbstub_be_step (const int xlen);
+uint32_t  gdbstub_be_step (const uint8_t xlen);
 
 // ================================================================
 // Stop the HW execution
 
 extern
-uint32_t  gdbstub_be_stop (const int xlen);
+uint32_t  gdbstub_be_stop (const uint8_t xlen);
 
 // ================================================================
 // Get stop-reason from HW
 // (HW normally stops due to GDB ^C, after a 'step', or at a breakpoint)
 
 extern
-uint32_t  gdbstub_be_get_stop_reason (const int xlen, uint8_t *p_stop_reason);
+int32_t  gdbstub_be_get_stop_reason (const uint8_t xlen, uint8_t *p_stop_reason);
 
 // ================================================================
 // This is not a debugger function at all, just an aid for humans
@@ -108,90 +108,90 @@ uint32_t  gdbstub_be_get_stop_reason (const int xlen, uint8_t *p_stop_reason);
 // responses corresponding to a single GDB command.
 
 extern
-uint32_t  gdbstub_be_start_command (const int xlen);
+uint32_t  gdbstub_be_start_command (const uint8_t xlen);
 
 // ================================================================
 // Read a value from the PC
 
 extern
-uint32_t  gdbstub_be_PC_read (const int xlen, uint64_t *p_PC);
+uint32_t  gdbstub_be_PC_read (const uint8_t xlen, uint64_t *p_PC);
 
 // ================================================================
 // Read a value from a GPR register in SoC
 
 extern
-uint32_t  gdbstub_be_GPR_read (const int xlen, uint32_t regnum, uint64_t *p_regval);
+uint32_t  gdbstub_be_GPR_read (const uint8_t xlen, uint8_t regnum, uint64_t *p_regval);
 
 // ================================================================
 // Read a value from a FPR register in SoC
 
 extern
-uint32_t  gdbstub_be_FPR_read (const int xlen, uint32_t regnum, uint64_t *p_regval);
+uint32_t  gdbstub_be_FPR_read (const uint8_t xlen, uint8_t regnum, uint64_t *p_regval);
 
 // ================================================================
 // Read a value from a CSR in SoC
 
 extern
-uint32_t  gdbstub_be_CSR_read (const int xlen, uint32_t regnum, uint64_t *p_regval);
+uint32_t  gdbstub_be_CSR_read (const uint8_t xlen, uint16_t regnum, uint64_t *p_regval);
 
 // ================================================================
 // Read 1, 2 or 4 bytes from SoC memory at address 'addr' into 'data'
 
 extern
-uint32_t  gdbstub_be_mem_read_subword (const int       xlen,
+uint32_t  gdbstub_be_mem_read_subword (const uint8_t   xlen,
 				       const uint64_t  addr,
-				       uint64_t       *data,
-				       const uint32_t  len);
+				       uint32_t       *data,
+				       const size_t    len);
 
 // ================================================================
 // Read 'len' bytes from SoC memory starting at address 'addr' into 'data'.
 // No alignment restriction on 'addr'; no restriction on 'len'.
 
 extern
-uint32_t  gdbstub_be_mem_read (const int       xlen,
+uint32_t  gdbstub_be_mem_read (const uint8_t   xlen,
 			       const uint64_t  addr,
-			       uint8_t        *data,
-			       const uint32_t  len);
+			       char           *data,
+			       const size_t    len);
 
 // ================================================================
 // Write a value into the RISC-V PC
 
 extern
-uint32_t  gdbstub_be_PC_write (const int xlen, uint64_t regval);
+uint32_t  gdbstub_be_PC_write (const uint8_t xlen, uint64_t regval);
 
 // ================================================================
 // Write a value into a RISC-V GPR register
 
 extern
-uint32_t  gdbstub_be_GPR_write (const int xlen, uint32_t regnum, uint64_t regval);
+uint32_t  gdbstub_be_GPR_write (const uint8_t xlen, uint8_t regnum, uint64_t regval);
 
 // ================================================================
 // Write a value into a RISC-V FPR register
 
 extern
-uint32_t  gdbstub_be_FPR_write (const int xlen, uint32_t regnum, uint64_t regval);
+uint32_t  gdbstub_be_FPR_write (const uint8_t xlen, uint8_t regnum, uint64_t regval);
 
 // ================================================================
 // Write a value into a RISC-V CSR register
 
 extern
-uint32_t  gdbstub_be_CSR_write (const int xlen, uint32_t regnum, uint64_t regval);
+uint32_t  gdbstub_be_CSR_write (const uint8_t xlen, uint16_t regnum, uint64_t regval);
 
 // ================================================================
 // Write 'len' bytes of 'data' into RISC-V system memory, starting at address 'addr'
 // where 'len' is 1, 2 or 4 only, and addr is aligned.
 
 extern
-uint32_t  gdbstub_be_mem_write_subword (const int       xlen,
+uint32_t  gdbstub_be_mem_write_subword (const uint8_t   xlen,
 					const uint64_t  addr,
-					const uint64_t  data,
-					const uint32_t  len);
+					const uint32_t  data,
+					const size_t    len);
 
 // ================================================================
 // Write 'len' bytes of 'data' into RISC-V system memory, starting at address 'addr'
 
 extern
-uint32_t  gdbstub_be_mem_write (const int xlen, const uint64_t addr, const uint8_t *data, const uint32_t len);
+uint32_t  gdbstub_be_mem_write (const uint8_t xlen, const uint64_t addr, const char *data, const size_t len);
 
 // ****************************************************************
 // ****************************************************************
@@ -202,12 +202,12 @@ uint32_t  gdbstub_be_mem_write (const int xlen, const uint64_t addr, const uint8
 // Raw DMI read
 
 extern
-uint32_t  gdbstub_be_dmi_read (uint32_t dmi_addr, uint64_t *p_data);
+uint32_t  gdbstub_be_dmi_read (uint16_t dmi_addr, uint32_t *p_data);
 
 // ================================================================
 // Raw DMI write
 
 extern
-uint32_t  gdbstub_be_dmi_write (uint32_t dmi_addr, uint64_t dmi_data);
+uint32_t  gdbstub_be_dmi_write (uint16_t dmi_addr, uint32_t dmi_data);
 
 // ================================================================

--- a/src/gdbstub_be.h
+++ b/src/gdbstub_be.h
@@ -35,7 +35,7 @@ const char *gdbstub_be_help (void);
 // Initialize gdbstub_be
 
 extern
-uint32_t  gdbstub_be_init (FILE *logfile);
+uint32_t  gdbstub_be_init (FILE *logfile, bool autoclose);
 
 // ================================================================
 // Final actions for gdbstub_be

--- a/src/gdbstub_dmi.h
+++ b/src/gdbstub_dmi.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2020 Bluespec, Inc. All Rights Reserved
+// Author: Rishiyur Nikhil
+
+// ================================================================
+
+#pragma once
+
+// ================================================================
+// DMI interface (gdbstub invokes these functions)
+// These should be filled in with the appropriate mechanisms that
+// perform the actual DMI read/write on the RISC-V Debug module.
+
+extern void      dmi_write (uint16_t addr, uint32_t data);
+extern uint32_t  dmi_read  (uint16_t addr);
+
+// ================================================================

--- a/src/gdbstub_dmi_stub.c
+++ b/src/gdbstub_dmi_stub.c
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2020 Bluespec, Inc. All Rights Reserved
+// Author: Rishiyur Nikhil
+
+// ================================================================
+// Stub implementation of DMI read/write functions
+
+// ================================================================
+// C lib includes
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+// ----------------
+// Project includes
+
+#include  "RVDM.h"
+
+// ================================================================
+// DMI interface (gdbstub invokes these functions)
+// These should be filled in with the appropriate mechanisms that
+// perform the actual DMI read/write on the RISC-V Debug module.
+
+void dmi_write (uint16_t addr, uint32_t data)
+{
+    fprintf (stderr, "RVDM.c: dmi_write(): Not yet implemented\n");
+}
+
+uint32_t  dmi_read  (uint16_t addr)
+{
+    fprintf (stderr, "RVDM.c: dmi_read(): Not yet implemented\n");
+    return 0;
+}

--- a/src/gdbstub_fe.c
+++ b/src/gdbstub_fe.c
@@ -861,7 +861,7 @@ static
 void handle_RSP_control_C (const char *buf, const size_t buf_len)
 {
     uint32_t status = gdbstub_be_stop (gdbstub_be_xlen);
-    if (status == status_ok) {
+    if (status != status_ok) {
 	send_OK_or_error_response (status_err);
 	return;
     }

--- a/src/gdbstub_fe.c
+++ b/src/gdbstub_fe.c
@@ -1535,8 +1535,8 @@ void *main_gdbstub (void *arg)
 	fflush (logfile);
     }
 
-    // Initialize the gdbstub_be
-    uint32_t status = gdbstub_be_init (logfile);
+    // Initialize the gdbstub_be (we own logfile)
+    uint32_t status = gdbstub_be_init (logfile, false);
     if (status != status_ok) {
 	if (logfile) {
 	    fprintf (logfile, "ERROR: gdbstub_fe.main_gdbstub: error in gdbstub_be_startup\n");

--- a/src/gdbstub_fe.c
+++ b/src/gdbstub_fe.c
@@ -43,7 +43,7 @@ static bool waiting_for_stop_reason = false;
 // Print a byte, using ASCII char if printable, escaped hex code if not
 
 static
-void fprint_byte (FILE *fp, const uint8_t x)
+void fprint_byte (FILE *fp, const char x)
 {
     if ((' ' <= x) && (x <= '~')) {
 	fprintf (fp, "%c", x);
@@ -57,12 +57,12 @@ void fprint_byte (FILE *fp, const uint8_t x)
 // Print a string of bytes, using ASCII printables if possible
 
 static
-void fprint_bytes (FILE *fp, const char *pre, const uint8_t *buf, const uint32_t buf_len, const char *post)
+void fprint_bytes (FILE *fp, const char *pre, const char *buf, const size_t buf_len, const char *post)
 {
     if (pre != NULL)
 	fprintf (fp, "%s", pre);
 
-    int j;
+    size_t j;
     for (j = 0; j < buf_len; j++)
 	fprint_byte (fp, buf [j]);
 
@@ -76,16 +76,16 @@ void fprint_bytes (FILE *fp, const char *pre, const uint8_t *buf, const uint32_t
 // $X data bytes are printed only in hex format, and only up to 64 bytes (if verbosity = 0)
 
 static
-void fprint_packet (FILE *fp, const char *pre, const uint8_t *buf, const int buf_len, const char *post)
+void fprint_packet (FILE *fp, const char *pre, const char *buf, const size_t buf_len, const char *post)
 {
     if ((buf_len >= 2) && (buf [0] == '$') && (buf [1] == 'X')) {
 	if (pre != NULL)
 	    fprintf (fp, "%s", pre);
 
-	const int trailer_len = 3;    // '#nn' at end of packet
+	const size_t trailer_len = 3;    // '#nn' at end of packet
 
 	// Print '$X addr, len :'
-	int j;
+	size_t j;
 	for (j = 0; (j < buf_len); j++) {
 	    fprintf (fp, "%c", buf [j]);
 	    if (buf [j] == ':') break;
@@ -94,7 +94,7 @@ void fprint_packet (FILE *fp, const char *pre, const uint8_t *buf, const int buf
 	assert ((j < (buf_len - trailer_len)) && (buf [j] == ':'));
 	j++; // Just past the ':'
 
-	int jmax = 64;
+	size_t jmax = 64;
 	if ((verbosity != 0) || ((buf_len - trailer_len - j) < 64))
 	    jmax = buf_len - trailer_len;
 
@@ -139,37 +139,39 @@ void fprint_packet (FILE *fp, const char *pre, const uint8_t *buf, const int buf
 // Returns the actual number of chars copied into dst, -1 if error.
 
 static
-int gdb_escape (unsigned char *dst, const int dst_size, const unsigned char *src, const int src_len)
+ssize_t gdb_escape (char *dst, const size_t dst_size, const char *src, const size_t src_len)
 {
-    int js = 0, jd = 0;
+    unsigned char *udst = (unsigned char *) dst;
+    const unsigned char *usrc = (const unsigned char *) src;
+    size_t js = 0, jd = 0;
 
     while (js < src_len) {
-	unsigned char ch = src [js];
+	unsigned char ch = usrc [js];
 	if ((ch == '$') || (ch == '#') || (ch == '*') || (ch == '}')) {
 	    if ((jd + 1) >= dst_size)
 		goto err_dst_too_small;
 	    dst [jd]     = '}';
-	    dst [jd + 1] = (ch ^ 0x20);
+	    udst [jd + 1] = (ch ^ 0x20);
 	    jd += 2;
 	}
 	else {
 	    if (jd >= dst_size)
 		goto err_dst_too_small;
-	    dst [jd] = ch;
+	    udst [jd] = ch;
 	    jd += 1;
 	}
 	js++;
     }
-    return jd;
+    return (ssize_t) jd;
 
  err_dst_too_small:
     fprintf (logfile, "ERROR: gdbstub_fe.gdb_escape: destination buffer too small\n");
-    fprintf (logfile, "    src [src_len %0d] = \"", src_len);
-    int j;
+    fprintf (logfile, "    src [src_len %0zu] = \"", src_len);
+    size_t j;
     for (j = 0; j < src_len; j++) fprintf (logfile, "%c", src [j]);
     fprintf (logfile, "\"\n");
-    fprintf (logfile, "    dst_size = %0d\n", dst_size);
-    fprintf (logfile, "    At src [%0d], dst [%0d]\n", js, jd);
+    fprintf (logfile, "    dst_size = %0zu\n", dst_size);
+    fprintf (logfile, "    At src [%0zu], dst [%0zu]\n", js, jd);
     return -1;
 }
 
@@ -180,9 +182,11 @@ int gdb_escape (unsigned char *dst, const int dst_size, const unsigned char *src
 //    (includes terminating 0 byte)
 
 static
-int gdb_unescape (unsigned char *dst, const int dst_size, const unsigned char *src, const int src_len)
+ssize_t gdb_unescape (char *dst, const size_t dst_size, const char *src, const size_t src_len)
 {
-    int js = 0, jd = 0;
+    unsigned char *udst = (unsigned char *) dst;
+    const unsigned char *usrc = (const unsigned char *) src;
+    size_t js = 0, jd = 0;
 
     while (js < src_len) {
 	unsigned char ch;
@@ -190,37 +194,37 @@ int gdb_unescape (unsigned char *dst, const int dst_size, const unsigned char *s
 	    if ((js + 1) >= src_len)
 		goto err_ends_in_escape_char;
 
-	    ch = src [js + 1] ^ 0x20;
+	    ch = usrc [js + 1] ^ 0x20;
 	    js += 2;
 	}
 	else {
-	    ch = src [js];
+	    ch = usrc [js];
 	    js += 1;
 	}
 
 	if (jd >= dst_size)
 	    goto err_dst_too_small;
-	dst [jd++] = ch;
+	udst [jd++] = ch;
     }
     // Insert terminating 0 byte
     if ((jd + 1) >= dst_size)
 	goto err_dst_too_small;
-    dst  [jd++] = 0;
-    return jd;
+    dst [jd++] = 0;
+    return (ssize_t) jd;
 
  err_dst_too_small:
     fprintf (logfile, "ERROR: gdbstub_fe.gdb_unescape: destination buffer too small\n");
-    fprintf (logfile, "    src [src_len %0d] = \"", src_len);
-    int j;
+    fprintf (logfile, "    src [src_len %0zu] = \"", src_len);
+    size_t j;
     for (j = 0; j < src_len; j++) fprintf (logfile, "%c", src [j]);
     fprintf (logfile, "\"\n");
-    fprintf (logfile, "    dst_size = %0d\n", dst_size);
-    fprintf (logfile, "    At src [%0d], dst [%0d]\n", js, jd);
+    fprintf (logfile, "    dst_size = %0zu\n", dst_size);
+    fprintf (logfile, "    At src [%0zu], dst [%0zu]\n", js, jd);
     return -1;
 
  err_ends_in_escape_char:
     fprintf (logfile, "ERROR: gdbstub_fe.gdb_unescape: last char of src is escape char\n");
-    fprintf (logfile, "    src [src_len %0d] = \"", src_len);
+    fprintf (logfile, "    src [src_len %0zu] = \"", src_len);
     for (j = 0; j < src_len; j++) fprintf (logfile, "%c", src [j]);
     fprintf (logfile, "\"\n");
     return -1;
@@ -230,14 +234,13 @@ int gdb_unescape (unsigned char *dst, const int dst_size, const unsigned char *s
 // Compute 8-bit unsigned checksum of chars in a buffer
 
 static
-int gdb_checksum (const unsigned char *buf, const int size)
+uint8_t gdb_checksum (const char *buf, const size_t size)
 {
-    const unsigned char *bufend = buf + size;
-    unsigned char c = 0;
+    uint8_t c = 0;
 
-    int j;
+    size_t j;
     for (j = 0; j < size; j++)
-	c += buf [j];
+	c = (uint8_t) (c + ((uint8_t *) buf) [j]);
 
     return c;
 }
@@ -251,10 +254,10 @@ int gdb_checksum (const unsigned char *buf, const int size)
 //    (but only up to the the first DEST_MAX-1 chars of the token)
 
 static
-int find_token (unsigned char *dest, const int DEST_MAX, const unsigned char *src, const int src_len)
+size_t find_token (char *dest, const size_t DEST_MAX, const char *src, const size_t src_len)
 {
-    int js = 0;
-    int jd = 0;
+    size_t js = 0;
+    size_t jd = 0;
 
     // Skip leading whitespace if any
     while ((js < src_len)
@@ -282,11 +285,11 @@ int find_token (unsigned char *dest, const int DEST_MAX, const unsigned char *sr
 // Return 0 if ok, -1 if err
 
 static
-int send_ack_nak (unsigned char ack_char)
+int send_ack_nak (char ack_char)
 {
-    uint32_t n_iters = 0;
+    size_t n_iters = 0;
     while (true) {
-	int n = write (gdb_fd, & ack_char, 1);
+	ssize_t n = write (gdb_fd, & ack_char, 1);
 	if (n < 0) {
 	    fprintf (logfile, "ERROR: gdbstub_fe.send_ack_nak: write (ack_char '%c') failed\n", ack_char);
 	    perror (NULL);
@@ -313,18 +316,18 @@ int send_ack_nak (unsigned char ack_char)
 // Return '+' if ack, '-' if nak, 'E' if err
 
 static
-unsigned char recv_ack_nak (void)
+char recv_ack_nak (void)
 {
-    const uint32_t n_iters_max = 1000000;
-    uint32_t n_iters = 0;
-    unsigned char ack_char;
+    const size_t n_iters_max = 1000000;
+    size_t n_iters = 0;
+    char ack_char;
     while (true) {
-	int n = read (gdb_fd, & ack_char, 1);
+	ssize_t n = read (gdb_fd, & ack_char, 1);
 	if (n < 0) {
 	    if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
 		// Nothing available yet
 		if (n_iters > n_iters_max) {
-		    fprintf (logfile, "ERROR: gdbstub_fe.recv_ack_nak: nothing received in %0d read () attempts\n",
+		    fprintf (logfile, "ERROR: gdbstub_fe.recv_ack_nak: nothing received in %0zu read () attempts\n",
 			     n_iters_max);
 		    return 'E';
 		}
@@ -340,7 +343,7 @@ unsigned char recv_ack_nak (void)
 	}
 	else if (n == 0) {
 	    if (n_iters > n_iters_max) {
-		fprintf (logfile, "ERROR: gdbstub_fe.recv_ack_nak: nothing received in %0d read () attempts\n",
+		fprintf (logfile, "ERROR: gdbstub_fe.recv_ack_nak: nothing received in %0zu read () attempts\n",
 			 n_iters_max);
 		return 'E';
 	    }
@@ -366,15 +369,15 @@ unsigned char recv_ack_nak (void)
 static
 uint8_t value_of_hex_digit (char ch)
 {
-    if      ((ch >= 'a') && (ch <= 'f')) return (ch - 'a' + 10);
-    else if ((ch >= 'A') && (ch <= 'F')) return (ch - 'A' + 10);
-    else if ((ch >= '0') && (ch <= '9')) return (ch - '0');
+    if      ((ch >= 'a') && (ch <= 'f')) return (uint8_t) (ch - 'a' + 10);
+    else if ((ch >= 'A') && (ch <= 'F')) return (uint8_t) (ch - 'A' + 10);
+    else if ((ch >= '0') && (ch <= '9')) return (uint8_t) (ch - '0');
     else {
 	fprintf (logfile, "ERROR: gdbstub_fe.value_of_hex_digit () argument is not a hex digit\n");
 	fprintf (logfile, "    arg value is: ");
 	fprint_byte (logfile, ch);
 	fprintf (logfile, "\n");
-	return -1;
+	return 0xFF;
     }
 }
 
@@ -390,7 +393,7 @@ static
 const char hexchars[] = "0123456789abcdef";
 
 static
-void val_to_hex16 (const uint64_t val, const int xlen, char *buf)
+void val_to_hex16 (const uint64_t val, const uint8_t xlen, char *buf)
 {
     assert ((xlen == 8)
 	    || (xlen == 16)
@@ -428,11 +431,11 @@ void val_to_hex16 (const uint64_t val, const int xlen, char *buf)
 //     4 chars if word_size = 16
 //     8 chars if word_size = 32
 //    16 chars if word_size = 64
-// Returns 0 if ok
-//        -1 if error (ASCII char is not a hex digit)
+// Returns status_ok  - if ok
+//         status_err - if error (ASCII char is not a hex digit)
 
 static
-int hex16_to_val (const char *buf, const int xlen, uint64_t *p_val)
+uint32_t hex16_to_val (const char *buf, const uint8_t xlen, uint64_t *p_val)
 {
     assert ((xlen == 8)
 	    || (xlen == 16)
@@ -440,13 +443,13 @@ int hex16_to_val (const char *buf, const int xlen, uint64_t *p_val)
 	    || (xlen == 64));
 
     uint64_t val = 0;
-    const int num_ASCII_hex_digits = (xlen/8) * 2;
+    const size_t num_ASCII_hex_digits = xlen / (8 / 2);
 
     // Check that they are all ASCII hex digits
-    int j;
+    size_t j;
     for (j = 0; j < num_ASCII_hex_digits; j++) {
 	if (! isxdigit (buf [j]))
-	    return -1;
+	    return status_err;
     }
 
     // Convert
@@ -458,23 +461,24 @@ int hex16_to_val (const char *buf, const int xlen, uint64_t *p_val)
     }
 
     *p_val = val;
-    return 0;
+    return status_ok;
 }
 
 // ================================================================
 // Convert 'len' hex digits (2 per byte) in 'src' into bytes in 'dest'
 
 static
-void hex2bin (uint8_t *dest, const uint8_t *src, int len)
+void hex2bin (char *dest, const char *src, size_t len)
 {
+    uint8_t *udest = (uint8_t *) dest;
     uint8_t x, y;
     int jd = 0;
 
-    int js;
+    size_t js;
     for (js = 0; js < len; js += 2) {
 	x = value_of_hex_digit (src [js]);
 	y = value_of_hex_digit (src [js + 1]);
-	dest [jd] = ((x << 4) | y);
+	udest [jd] = (uint8_t) ((x << 4) | y);
 	jd++;
     }
 }
@@ -483,15 +487,15 @@ void hex2bin (uint8_t *dest, const uint8_t *src, int len)
 // Convert 'len' bytes in 'src' into hex digits (2 per byte) in 'dest'
 
 static
-void bin2hex (uint8_t *dest, const uint8_t *src, int len)
+void bin2hex (char *dest, const char *src, size_t len)
 {
-    uint8_t x, y;
-    int jd = 0;
+    const uint8_t *usrc = (const uint8_t *) src;
+    size_t jd = 0;
 
-    int js;
+    size_t js;
     for (js = 0; js < len; js++) {
-	uint8_t ch_upper = hexchars [(src [js] >> 4) & 0x0F];
-	uint8_t ch_lower = hexchars [(src [js] >> 0) & 0x0F];
+	char ch_upper = hexchars [(usrc [js] >> 4) & 0x0F];
+	char ch_lower = hexchars [(usrc [js] >> 0) & 0x0F];
 	dest [jd]     = ch_upper;
 	dest [jd + 1] = ch_lower;
 	jd += 2;
@@ -501,27 +505,28 @@ void bin2hex (uint8_t *dest, const uint8_t *src, int len)
 // ================================================================
 // Send a GDB RSP packet to GDB ("$....#xx").
 // After sending, get a '+' (ack) or '-' (nak) response from GDB.
-// Returns
-//      0 on success
-//     -1 on error
+// Returns status_ok  - if ok
+//         status_err - if error
 
 static
-int send_RSP_packet_to_GDB (const unsigned char *buf, const int buf_len)
+uint32_t send_RSP_packet_to_GDB (const char *buf, const size_t buf_len)
 {
-    unsigned char wire_buf [GDB_RSP_WIRE_BUF_MAX];
+    char wire_buf [GDB_RSP_WIRE_BUF_MAX];
 
     wire_buf [0] = '$';
 
     // Copy the payload from buf to wire_buf, escaping bytes as necessary
-    int wire_len = gdb_escape (& (wire_buf [1]), (GDB_RSP_WIRE_BUF_MAX - 1), buf, buf_len);
-    if ((wire_len < 0) || ((wire_len + 4) >= GDB_RSP_WIRE_BUF_MAX)) {
+    ssize_t s_wire_len = gdb_escape (& (wire_buf [1]), (GDB_RSP_WIRE_BUF_MAX - 1), buf, buf_len);
+    if ((s_wire_len < 0) || ((s_wire_len + 4) >= GDB_RSP_WIRE_BUF_MAX)) {
 	fprintf (logfile, "ERROR: gdbstub_fe.send_RSP_packet_to_GDB: packet too large\n");
 	fprintf (logfile, "    Encoded packet will not fit in wire_buf [%0d]\n", GDB_RSP_WIRE_BUF_MAX);
 	goto err_exit;
     }
 
+    size_t wire_len = (size_t) s_wire_len;
+
     // Compute and insert the checksum
-    int  checksum = gdb_checksum (& (wire_buf [1]), wire_len);
+    uint8_t checksum = gdb_checksum (& (wire_buf [1]), wire_len);
     char ckstr [3];
     snprintf (ckstr, sizeof (ckstr), "%02X", checksum);
     wire_buf [wire_len + 1] = '#';
@@ -530,10 +535,10 @@ int send_RSP_packet_to_GDB (const unsigned char *buf, const int buf_len)
 
     while (true) {
 	// Write the packet out to GDB
-	int n_sent = 0;
-	uint32_t n_iters = 0;
+	size_t n_sent = 0;
+	size_t n_iters = 0;
 	while (n_sent < (wire_len + 4)) {
-	    int n = write (gdb_fd, & (wire_buf [n_sent]), (wire_len + 4 - n_sent));
+	    ssize_t n = write (gdb_fd, & (wire_buf [n_sent]), (wire_len + 4 - n_sent));
 	    if (n < 0) {
 		fprintf (logfile, "ERROR: gdbstub_fe.send_RSP_packet_to_GDB: write (wire_buf) failed\n");
 		goto err_exit;
@@ -542,22 +547,22 @@ int send_RSP_packet_to_GDB (const unsigned char *buf, const int buf_len)
 		if (n_iters > 1000000) {
 		    fprintf (logfile,
 			     "ERROR: gdbstub_fe.send_RSP_packet_to_GDB: nothing sent in 1,000,000 write () attempts\n");
-		    return 'E';
+		    goto err_exit;
 		}
 		usleep (5);
 		n_iters++;
 	    }
 	    else {
-		n_sent += n;
+		n_sent += (size_t) n;
 	    }
 	}
 	// Debug
 	fprint_bytes (logfile, "w ", wire_buf, wire_len + 4, "\n");
 
 	// Receive '+' (ack) or '-' (nak) from GDB
-	unsigned char ch = recv_ack_nak ();
+	char ch = recv_ack_nak ();
 	if (ch == '+')
-	    return 0;
+	    return status_ok;
 	else {
 	    fprintf (logfile, "Received nak ('-') from GDB\n");
 	    continue; // goto err_exit;
@@ -565,11 +570,11 @@ int send_RSP_packet_to_GDB (const unsigned char *buf, const int buf_len)
     }
 
  err_exit:
-    fprintf (logfile, "    buf [buf_len %0d] = \"", buf_len);
-    int j;
+    fprintf (logfile, "    buf [buf_len %0zu] = \"", buf_len);
+    size_t j;
     for (j = 0; j < buf_len; j++) fprintf (logfile, "%c", buf [j]);
     fprintf (logfile, "\"\n");
-    return -1;
+    return status_err;
 }
 
 // ================================================================
@@ -593,17 +598,17 @@ int send_RSP_packet_to_GDB (const unsigned char *buf, const int buf_len)
 
 #define DEBUG_recv_RSP_packet_from_GDB false
 static
-int recv_RSP_packet_from_GDB (unsigned char *buf, const int buf_size)
+ssize_t recv_RSP_packet_from_GDB (char *buf, const size_t buf_size)
 {
     // The sliding window
-    static unsigned char wire_buf [GDB_RSP_WIRE_BUF_MAX];
-    static int free_ptr = 0;
+    static char wire_buf [GDB_RSP_WIRE_BUF_MAX];
+    static size_t free_ptr = 0;
 
     // Invariant: all chars [0..] are relevant.
     // Established by moving relevant chars down to [0..] before returning.
     // Specifically, [0] contains the '$' of the next packet.
 
-    int n;
+    ssize_t n;
 
     struct pollfd fds [1];
     fds[0].fd = gdb_fd;
@@ -625,25 +630,25 @@ int recv_RSP_packet_from_GDB (unsigned char *buf, const int buf_size)
 	    return -1;
 	}
 	else {
-	    free_ptr += n;
+	    free_ptr += (size_t) n;
 	}
     }
 
     // Scan for the starting '$' of the packet, or ^C
-    int start = 0;
+    size_t start = 0;
     while ((wire_buf [start] != '$') && (wire_buf [start] != control_C) && (start < free_ptr)) {
 	start++;
     }
 
     if (DEBUG_recv_RSP_packet_from_GDB) {
         fprintf (logfile,
-                "recv_RSP_packet_from_GDB:DBG: free_ptr=%d, n=%d, start=%d\n",
+                "recv_RSP_packet_from_GDB:DBG: free_ptr=%zu, n=%zd, start=%zu\n",
                 free_ptr, n, start);
     }
 
     // discard garbage before packet, if any
     if (start != 0) {
-	fprintf (logfile, "WARNING: gdbstub_fe.recv_RSP_packet_from_GDB: %0d junk chars before '$'; ignoring:\n",
+	fprintf (logfile, "WARNING: gdbstub_fe.recv_RSP_packet_from_GDB: %0zu junk chars before '$'; ignoring:\n",
 		 start);
 	fprint_bytes (logfile, "    [", wire_buf, start, "]\n");
 
@@ -663,7 +668,7 @@ int recv_RSP_packet_from_GDB (unsigned char *buf, const int buf_size)
     // Check for ^C
     if (wire_buf [0] == control_C) {
 	if (buf_size < 2) {
-	    fprintf (logfile, "ERROR: gdbstub_fe.recv_RSP_packet_from_GDB: buf_size too small: %0d\n", buf_size);
+	    fprintf (logfile, "ERROR: gdbstub_fe.recv_RSP_packet_from_GDB: buf_size too small: %0zu\n", buf_size);
 	    return -1;
 	}
 
@@ -685,7 +690,7 @@ int recv_RSP_packet_from_GDB (unsigned char *buf, const int buf_size)
     // assert (wire_buf [0]  == '$');
 
     // Scan for the ending '#' of the packet from [1] onwards
-    int end = 1;
+    size_t end = 1;
     while (wire_buf [end] != '#') {
 	if (end == (free_ptr - 1))
 	    return 0;
@@ -706,15 +711,15 @@ int recv_RSP_packet_from_GDB (unsigned char *buf, const int buf_size)
     fprint_packet (logfile, "r ", wire_buf, end + 3, "\n");
 
     // Compute the checksum of the received chars
-    int computed_checksum = gdb_checksum (& (wire_buf [1]), (end - 1));
+    uint8_t computed_checksum = gdb_checksum (& (wire_buf [1]), (end - 1));
 
     // Decode the received checksum
     char ckstr[3] = {(char) wire_buf [end + 1], (char) wire_buf [end + 2], 0};
-    int received_checksum = strtol (ckstr, NULL, 16);
+    uint8_t received_checksum = (uint8_t) strtoul (ckstr, NULL, 16);
 
-    unsigned char ack_char;
+    char ack_char;
 
-    int ret;    // final return value
+    ssize_t ret;    // final return value
     if (computed_checksum != received_checksum) {
 	// checksum failed
 	ack_char = '-';
@@ -753,10 +758,9 @@ int recv_RSP_packet_from_GDB (unsigned char *buf, const int buf_size)
 // Send "OK" or "ENN" response (NN = status) to GDB
 
 static
-void send_OK_or_error_response (int status)
+void send_OK_or_error_response (uint32_t status)
 {
     if (status == 0) {
-
 	send_RSP_packet_to_GDB ("OK", 2);
     }
     else {
@@ -781,10 +785,10 @@ void send_stop_reason (const uint8_t stop_reason)
 // '^C': respond to '^C' received from GDB (interrupt)
 
 static
-void handle_RSP_control_C (const unsigned char *buf, const int buf_len)
+void handle_RSP_control_C (const char *buf, const size_t buf_len)
 {
-    int status = gdbstub_be_stop (gdbstub_be_xlen);
-    if (status != 0) {
+    uint32_t status = gdbstub_be_stop (gdbstub_be_xlen);
+    if (status == status_ok) {
 	send_OK_or_error_response (0x01);
 	return;
     }
@@ -795,10 +799,10 @@ void handle_RSP_control_C (const unsigned char *buf, const int buf_len)
 // '?': Respond to '$?#xx' packet received from GDB (query stop-reason)
 
 static
-void handle_RSP_stop_reason (const unsigned char *buf, const int buf_len)
+void handle_RSP_stop_reason (const char *buf, const size_t buf_len)
 {
     uint8_t stop_reason;
-    int sr = gdbstub_be_get_stop_reason (gdbstub_be_xlen, & stop_reason);
+    int32_t sr = gdbstub_be_get_stop_reason (gdbstub_be_xlen, & stop_reason);
     if (sr == 0) {
         send_stop_reason (stop_reason);
         waiting_for_stop_reason = false;
@@ -822,9 +826,9 @@ void handle_RSP_stop_reason (const unsigned char *buf, const int buf_len)
 // addr is resume-PC, and is optional; if missing, resume from current PC
 
 static
-void handle_RSP_c_continue (const unsigned char *buf, const int buf_len)
+void handle_RSP_c_continue (const char *buf, const size_t buf_len)
 {
-    int       status;
+    uint32_t  status;
     uint64_t  PC_val;
 
     // "c" (no addr given)
@@ -842,7 +846,7 @@ void handle_RSP_c_continue (const unsigned char *buf, const int buf_len)
 
     // Send 'continue' command to HW side
     status = gdbstub_be_continue (gdbstub_be_xlen);
-    if (status != 0) {
+    if (status != status_ok) {
 	send_OK_or_error_response (status);
 	return;
     }
@@ -855,9 +859,9 @@ void handle_RSP_c_continue (const unsigned char *buf, const int buf_len)
 // 'D': respond to '$Dxx' packet received from GDB (shutdown)
 
 static
-void handle_RSP_shutdown (const unsigned char *buf, const int buf_len)
+void handle_RSP_shutdown (const char *buf, const size_t buf_len)
 {
-    int status = gdbstub_be_final (gdbstub_be_xlen);
+    uint32_t status = gdbstub_be_final (gdbstub_be_xlen);
     send_OK_or_error_response (status);
 }
 
@@ -870,18 +874,18 @@ void handle_RSP_shutdown (const unsigned char *buf, const int buf_len)
 //     FPRs: 0x21..0x40
 
 static
-void handle_RSP_g_read_all_registers (const unsigned char *buf, const int buf_len)
+void handle_RSP_g_read_all_registers (const char *buf, const size_t buf_len)
 {
-    int       status;
-    uint64_t  value;
-    char      response [33 * 16];
-    const int num_ASCII_hex_digits = (gdbstub_be_xlen/8) * 2;
+    uint32_t     status;
+    uint64_t     value;
+    char         response [33 * 16];
+    const size_t num_ASCII_hex_digits = gdbstub_be_xlen / (8 / 2);
 
     // GPRs
     uint8_t j;
     for (j = 0; j < 32; j++) {
 	status = gdbstub_be_GPR_read (gdbstub_be_xlen, j, & value);
-	if (status != 0) {
+	if (status != status_ok) {
 	    send_OK_or_error_response (0x01);
 	    return;
 	}
@@ -890,7 +894,7 @@ void handle_RSP_g_read_all_registers (const unsigned char *buf, const int buf_le
 
     // PC
     status = gdbstub_be_PC_read (gdbstub_be_xlen, & value);
-    if (status != 0) {
+    if (status != status_ok) {
 	send_OK_or_error_response (0x01);
 	return;
     }
@@ -911,28 +915,29 @@ void handle_RSP_g_read_all_registers (const unsigned char *buf, const int buf_le
 //     FPRs: 0x21..0x40
 
 static
-void handle_RSP_G_write_all_registers (const unsigned char *buf, const int buf_len)
+void handle_RSP_G_write_all_registers (const char *buf, const size_t buf_len)
 {
-    int       status;
+    uint32_t  status;
     uint64_t  GPR_vals [32];
     uint64_t  PC_val;
-    uint64_t  FPR_vals [32];
-    uint64_t  FSR_val;
-    const int num_ASCII_hex_digits = (gdbstub_be_xlen/8) * 2;
+    // TODO
+    //uint64_t  FPR_vals [32];
+    //uint64_t  FSR_val;
+    const size_t num_ASCII_hex_digits = gdbstub_be_xlen / (8 / 2);
 
     // Check that the packet has the right number of hex digits for all the regs
     if (buf_len != 33 * num_ASCII_hex_digits) {
-	fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): invalid buf_len (%0d)\n", buf_len);
-	fprintf (logfile, "    Expecting exactly 33 x %0d hex digits\n", num_ASCII_hex_digits);
+	fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): invalid buf_len (%0zu)\n", buf_len);
+	fprintf (logfile, "    Expecting exactly 33 x %0zu hex digits\n", num_ASCII_hex_digits);
 	goto error_response;
     }
 
     // Parse all the GPR values
-    int j;
+    uint8_t j;
     for (j = 0; j < 32; j++) {
 	status = hex16_to_val (& (buf [j * num_ASCII_hex_digits]), gdbstub_be_xlen, & (GPR_vals [j]));
-	if (status != 0) {
-	    fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): error parsing val for reg %0d\n",
+	if (status != status_ok) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): error parsing val for reg %0u\n",
 		     j);
 	    goto error_response;
 	}
@@ -940,7 +945,7 @@ void handle_RSP_G_write_all_registers (const unsigned char *buf, const int buf_l
 
     // Parse the PC value
     status = hex16_to_val (& (buf [32 * num_ASCII_hex_digits]), gdbstub_be_xlen, & PC_val);
-    if (status != 0) {
+    if (status != status_ok) {
 	fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): error parsing val for PC\n");
 	goto error_response;
     }
@@ -948,8 +953,8 @@ void handle_RSP_G_write_all_registers (const unsigned char *buf, const int buf_l
     // Write GPRs to HW
     for (j = 0; j < 32; j++) {
 	status = gdbstub_be_GPR_write (gdbstub_be_xlen, j, GPR_vals [j]);
-	if (status != 0) {
-	    fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): error writing val for reg %0d\n",
+	if (status != status_ok) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): error writing val for reg %0u\n",
 		     j);
 	    goto error_response;
 	}
@@ -957,7 +962,7 @@ void handle_RSP_G_write_all_registers (const unsigned char *buf, const int buf_l
 
     // Write PC to HW
     status = gdbstub_be_PC_write (gdbstub_be_xlen, PC_val);
-    if (status != 0) {
+    if (status != status_ok) {
 	fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): error writing val for PC\n");
 	goto error_response;
     }
@@ -977,12 +982,13 @@ void handle_RSP_G_write_all_registers (const unsigned char *buf, const int buf_l
 // 'm': respond to '$m addr, len #xx' packet received from GDB (read memory)
 
 static
-void handle_RSP_m_read_mem (const unsigned char *buf, const int buf_len)
+void handle_RSP_m_read_mem (const char *buf, const size_t buf_len)
 {
     // Parse the addr and len in the RSP command
-    uint64_t addr, length;
+    uint64_t addr;
+    size_t length;
 
-    if (2 != sscanf (buf, "m%" SCNx64 ",%" SCNx64 "", & addr, & length)) {
+    if (2 != sscanf (buf, "m%" SCNx64 ",%zx", & addr, & length)) {
 	fprintf (logfile, "ERROR: gdbstub_fe.packet '$m...' packet from GDB: unable to parse addr, len\n");
 	send_OK_or_error_response (0x01);
 	return;
@@ -993,18 +999,18 @@ void handle_RSP_m_read_mem (const unsigned char *buf, const int buf_len)
 	length = (GDB_RSP_PKT_BUF_MAX - 1) / 2;
     }
 
-    uint8_t buf_bin [GDB_RSP_PKT_BUF_MAX / 2];
+    char buf_bin [GDB_RSP_PKT_BUF_MAX / 2];
 
     // Get memory data from HW
-    int status = gdbstub_be_mem_read (gdbstub_be_xlen, addr, buf_bin, length);
-    if (status != 0) {
+    uint32_t status = gdbstub_be_mem_read (gdbstub_be_xlen, addr, buf_bin, length);
+    if (status != status_ok) {
 	fprintf (logfile, "ERROR: gdbstub_fe.packet '$m...' packet from GDB: error reading HW memory\n");
 	send_OK_or_error_response (0x01);
 	return;
     }
 
     // Encode bytes into hex chars
-    uint8_t response [GDB_RSP_PKT_BUF_MAX];
+    char response [GDB_RSP_PKT_BUF_MAX];
     bin2hex (response, buf_bin, length);
 
     // Send response to GDB
@@ -1015,19 +1021,20 @@ void handle_RSP_m_read_mem (const unsigned char *buf, const int buf_len)
 // 'M': respond to '$M addr, len:XX...#xx' packet received from GDB (write mem, hex data)
 
 static void
-handle_RSP_M_write_mem_hex_data (const unsigned char *buf, const int buf_len)
+handle_RSP_M_write_mem_hex_data (const char *buf, const size_t buf_len)
 {
     // Parse the addr and len in the RSP command
-    uint64_t addr, length;
+    uint64_t addr;
+    size_t length;
 
-    if (2 != sscanf (buf, "M%" SCNx64 ",%" SCNx64 "", & addr, & length)) {
+    if (2 != sscanf (buf, "M%" SCNx64 ",%zx", & addr, & length)) {
 	fprintf (logfile, "ERROR: gdbstub_fe: packet '$M...' packet from GDB: unable to parse addr, len\n");
 	send_OK_or_error_response (0x01);
 	return;
     }
 
     // Find ':' separating length from bin data
-    uint8_t *p = (char *) (memchr (buf, ':', buf_len));
+    char *p = memchr (buf, ':', buf_len);
     if (p == NULL) {
 	fprintf (logfile, "ERROR: gdbstub_fe: packet '$M addr, len ...' packet from GDB: no ':' following len\n");
 	fprintf (logfile, "    addr = 0x%0" PRIx64 ", len = 0x%0" PRIx64 "\n", addr, length);
@@ -1036,23 +1043,23 @@ handle_RSP_M_write_mem_hex_data (const unsigned char *buf, const int buf_len)
     }
 
     // Check that it has the correct number of hex digits
-    uint32_t num_hex_data_digits = (buf_len - 1) - ((p + 1) - buf);
+    size_t num_hex_data_digits = (buf_len - 1) - ((size_t) ((p + 1) - buf));
     if (num_hex_data_digits != (length * 2)) {
 	fprintf (logfile,
 		 "ERROR: gdbstub_fe.packet '$M addr, len: ...' packet from GDB: fewer than (len*2) hex digits\n");
 	fprintf (logfile, "    addr = 0x%0" PRIx64 ", len = 0x%0" PRIx64 "\n", addr, length);
-	fprintf (logfile, "    # of hex data digits = %0d; len * 2 = 0x%0" PRId64 "\n",
+	fprintf (logfile, "    # of hex data digits = %0zu; len * 2 = 0x%0" PRId64 "\n",
 		 num_hex_data_digits, length * 2);
 	send_OK_or_error_response (0x03);
 	return;
     }
 
     // Convert from hex data digits to binary data
-    uint8_t buf_bin [GDB_RSP_PKT_BUF_MAX];
+    char buf_bin [GDB_RSP_PKT_BUF_MAX];
     hex2bin (buf_bin, (p + 1), length * 2);
 
     // Write the data to the HW side
-    int status = gdbstub_be_mem_write (gdbstub_be_xlen, addr, buf_bin, length);
+    uint32_t status = gdbstub_be_mem_write (gdbstub_be_xlen, addr, buf_bin, length);
     send_OK_or_error_response (status);
 }
 
@@ -1064,12 +1071,12 @@ handle_RSP_M_write_mem_hex_data (const unsigned char *buf, const int buf_len)
 //       n = 0x41..0x41+0xFFF  for CSRs
 
 static
-void handle_RSP_p_read_register (const unsigned char *buf, const int buf_len)
+void handle_RSP_p_read_register (const char *buf, const size_t buf_len)
 {
     uint32_t  regnum;
     uint64_t  value;
     char      response [16];
-    const int num_ASCII_hex_digits = (gdbstub_be_xlen/8) * 2;
+    const size_t num_ASCII_hex_digits = gdbstub_be_xlen / (8 / 2);
 
     if (1 != sscanf (buf, "p%x", & regnum)) {
 	send_OK_or_error_response (0x01);
@@ -1077,32 +1084,34 @@ void handle_RSP_p_read_register (const unsigned char *buf, const int buf_len)
     }
 
     if (regnum < 0x20) {
-	int status = gdbstub_be_GPR_read (gdbstub_be_xlen, regnum, & value);
-	if (status != 0) {
+	uint8_t gprnum = (uint8_t) regnum;
+	uint32_t status = gdbstub_be_GPR_read (gdbstub_be_xlen, gprnum, & value);
+	if (status != status_ok) {
 	    send_OK_or_error_response (0x01);
 	    return;
 	}
     }
     else if (regnum == 0x20) {
-	int status = gdbstub_be_PC_read (gdbstub_be_xlen, & value);
-	if (status != 0) {
+	uint32_t status = gdbstub_be_PC_read (gdbstub_be_xlen, & value);
+	if (status != status_ok) {
 	    send_OK_or_error_response (0x01);
 	    return;
 	}
     }
 
     else if ((0x21 <= regnum) && (regnum <= 0x40)) {
-	int status = gdbstub_be_FPR_read (gdbstub_be_xlen, regnum, & value);
-	if (status != 0) {
+	uint8_t fprnum = (uint8_t) (regnum - 0x21);
+	uint32_t status = gdbstub_be_FPR_read (gdbstub_be_xlen, fprnum, & value);
+	if (status != status_ok) {
 	    send_OK_or_error_response (0x01);
 	    return;
 	}
     }
 
     else if ((0x41 <= regnum) && (regnum <= (0x41 + 0xFFF))) {
-	uint32_t csr_addr = regnum - 0x41;
-	int status = gdbstub_be_CSR_read (gdbstub_be_xlen, csr_addr, & value);
-	if (status != 0) {
+	uint16_t csr_addr = (uint16_t) (regnum - 0x41);
+	uint32_t status = gdbstub_be_CSR_read (gdbstub_be_xlen, csr_addr, & value);
+	if (status != status_ok) {
 	    send_OK_or_error_response (0x01);
 	    return;
 	}
@@ -1127,9 +1136,9 @@ void handle_RSP_p_read_register (const unsigned char *buf, const int buf_len)
 //       n = 0x41..0x41+0xFFF  for CSRs
 
 static
-void handle_RSP_P_write_register (const unsigned char *buf, const int buf_len)
+void handle_RSP_P_write_register (const char *buf, const size_t buf_len)
 {
-    int      status;
+    uint32_t status;
     uint32_t regnum;
     uint64_t regval;
 
@@ -1151,7 +1160,7 @@ void handle_RSP_P_write_register (const unsigned char *buf, const int buf_len)
 
     // Parse the register value
     status = hex16_to_val (p, gdbstub_be_xlen, & regval);
-    if (status != 0) {
+    if (status != status_ok) {
 	fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_P_write_register (): error parsing value for register %0d\n",
 		 regnum);
 	status = 0x01;
@@ -1160,22 +1169,25 @@ void handle_RSP_P_write_register (const unsigned char *buf, const int buf_len)
 
     // Write the register
     if (regnum < 0x20) {
-	status = gdbstub_be_GPR_write (gdbstub_be_xlen, regnum, regval);
+	uint8_t gprnum = (uint8_t) regnum;
+	status = gdbstub_be_GPR_write (gdbstub_be_xlen, gprnum, regval);
     }
     else if (regnum == 0x20) {
 	status = gdbstub_be_PC_write (gdbstub_be_xlen, regval);
     }
     else if ((0x21 <= regnum) && (regnum <= 0x40)) {
-	status = gdbstub_be_FPR_write (gdbstub_be_xlen, regnum - 0x21, regval);
+	uint8_t fprnum = (uint8_t) (regnum - 0x21);
+	status = gdbstub_be_FPR_write (gdbstub_be_xlen, fprnum, regval);
     }
     else if ((0x41 <= regnum) && (regnum <= (0x41 + 0xFFF))) {
-	status = gdbstub_be_CSR_write (gdbstub_be_xlen, regnum - 0x41, regval);
+	uint16_t csr_addr = (uint16_t) (regnum - 0x41);
+	status = gdbstub_be_CSR_write (gdbstub_be_xlen, csr_addr, regval);
     }
     else
 	status = 01;
 
  done:
-    if (status != 0) {
+    if (status != status_ok) {
 	fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_P_write_register: gdbstub_be write error\n");
 	fprintf (logfile, "    regnum 0x%0x, regval 0x%0" PRIx64 "\n", regnum, regval);
     }
@@ -1190,38 +1202,38 @@ void handle_RSP_P_write_register (const unsigned char *buf, const int buf_len)
 #define WORD_MAX 128
 
 static void
-handle_RSP_qRcmd (const unsigned char *buf, const int buf_len)
+handle_RSP_qRcmd (const char *buf, const size_t buf_len)
 {
-    int     status = 0;
-    uint8_t response [GDB_RSP_PKT_BUF_MAX];
+    uint32_t status = status_ok;
+    char response [GDB_RSP_PKT_BUF_MAX];
 
-    unsigned char cmd [WORD_MAX];
-    int n = find_token (cmd, WORD_MAX, buf, buf_len);
+    char cmd [WORD_MAX];
+    size_t n = find_token (cmd, WORD_MAX, buf, buf_len);
 
     if (n == 0)
-	status = -1;
+	status = status_err;
 
     else if (strcmp (cmd, "help") == 0) {
-	const unsigned char *msg = gdbstub_be_help ();
+	const char *msg = gdbstub_be_help ();
 	response [0] = 'O';
-	int len = strlen (msg);
+	size_t len = strlen (msg);
 	bin2hex (& (response [1]), msg, len);
 	send_RSP_packet_to_GDB (response, 1 + (2 * len));
-	status = 0;
+	status = status_ok;
     }
     else if (strcmp (cmd, "verbosity") == 0) {
 	uint32_t verbosity;
-	n = sscanf (& (buf [n]), "%i", & verbosity);
-	if (n != 1)
-	    status = -1;
+	int m = sscanf (& (buf [n]), "%" SCNu32, & verbosity);
+	if (m != 1)
+	    status = status_err;
 	else
 	    status = gdbstub_be_verbosity (verbosity);
     }
     else if (strcmp (cmd, "xlen") == 0) {
-	uint32_t xlen;
-	n = sscanf (& (buf [n]), "%i", & xlen);
-	if (n != 1)
-	    status = -1;
+	uint8_t xlen;
+	int m = sscanf (& (buf [n]), "%" SCNu8, & xlen);
+	if (m != 1)
+	    status = status_err;
 	else {
 	    gdbstub_be_xlen = xlen;
 	    status = status_ok;
@@ -1243,28 +1255,26 @@ handle_RSP_qRcmd (const unsigned char *buf, const int buf_len)
     }
 
     else {
+	// Unrecognized command
 	// fprintf (logfile, "Monitor command not recognized\n");
-	status = -2;
+	send_RSP_packet_to_GDB ("", 0);
+	return;
     }
 
     // ----------------
     // Final response for the qRcmd command
-    if (status == 0) {
+    if (status == status_ok) {
 	// Ok
 	send_OK_or_error_response (0);
     }
-    else if (status == -1) {
+    else {
 	// Packet format error
 	send_OK_or_error_response (1);
-    }
-    else {
-	// Unrecognized command
-	send_RSP_packet_to_GDB ("", 0);
     }
 }
 
 static void
-handle_RSP_q (const unsigned char *buf, const int buf_len)
+handle_RSP_q (const char *buf, const size_t buf_len)
 {
     if (strncmp ("qAttached", buf, strlen ("qAttached")) == 0) {
 	char response [] = "1";    // i.e., gdbstub is attached to an existing process
@@ -1280,12 +1290,12 @@ handle_RSP_q (const unsigned char *buf, const int buf_len)
     else if (strncmp ("qRcmd,", buf, strlen ("qRcmd,")) == 0) {
 	// This is the RSP packet for 'monitor' commands
 	// Convert from hex data digits to binary data
-	int n1 = strlen ("qRcmd,");
-	int n2 = (buf_len - 1) - n1;    // Note: buf_len includes terminating 0 byte
-	int n3 = n2 / 2;
+	size_t n1 = strlen ("qRcmd,");
+	size_t n2 = (buf_len - 1) - n1;    // Note: buf_len includes terminating 0 byte
+	size_t n3 = n2 / 2;
 	assert ((n2 & 0x1) == 0);    // Even number of hex digits (ASCII codes)
-	uint8_t buf_bin [GDB_RSP_PKT_BUF_MAX];
-	const uint8_t *p = & (buf [n1]);
+	char buf_bin [GDB_RSP_PKT_BUF_MAX];
+	const char *p = & (buf [n1]);
 	hex2bin (buf_bin, p, n2);
 	buf_bin [n3] = 0;
 
@@ -1293,7 +1303,7 @@ handle_RSP_q (const unsigned char *buf, const int buf_len)
     }
 
     else {
-	fprintf (logfile, "WARNING: gdbstub_fe.handle_RSP_q: Unrecognized packet (%0d chars): ", buf_len - 1);
+	fprintf (logfile, "WARNING: gdbstub_fe.handle_RSP_q: Unrecognized packet (%0zu chars): ", buf_len - 1);
 	fprint_bytes (logfile, "", buf, buf_len - 1, "\n");
 
 	char response [] = "";
@@ -1306,9 +1316,9 @@ handle_RSP_q (const unsigned char *buf, const int buf_len)
 // addr is resume-PC, and is optional; if missing, resume from current PC
 
 static
-void handle_RSP_s_step (const unsigned char *buf, const int buf_len)
+void handle_RSP_s_step (const char *buf, const size_t buf_len)
 {
-    int       status;
+    uint32_t  status;
     uint64_t  PC_val;
 
     // "s" (no addr given)
@@ -1316,7 +1326,7 @@ void handle_RSP_s_step (const unsigned char *buf, const int buf_len)
 	/* DELETE
 	// Read the current PC from the HW
 	status = gdbstub_be_read_PC (& PC);
-	if (status != 0) {
+	if (status != status_ok) {
 	    send_OK_or_error_response (status);
 	    return;
 	}
@@ -1334,7 +1344,7 @@ void handle_RSP_s_step (const unsigned char *buf, const int buf_len)
 
     // Send 'step' command to HW side
     status = gdbstub_be_step (gdbstub_be_xlen);
-    if (status != 0) {
+    if (status != status_ok) {
 	send_OK_or_error_response (status);
 	return;
     }
@@ -1347,7 +1357,7 @@ void handle_RSP_s_step (const unsigned char *buf, const int buf_len)
 // 'X': respond to '$X addr, len:XX...#xx' packet received from GDB (write mem, binary data)
 
 static void
-handle_RSP_X_write_mem_bin_data (const unsigned char *buf, const int buf_len)
+handle_RSP_X_write_mem_bin_data (const char *buf, const size_t buf_len)
 {
     // Parse the addr and len in the RSP command
     uint64_t addr, length;
@@ -1359,7 +1369,7 @@ handle_RSP_X_write_mem_bin_data (const unsigned char *buf, const int buf_len)
     }
 
     // Find ':' separating length from bin data
-    uint8_t *p = (char *) (memchr (buf, ':', buf_len));
+    char *p = memchr (buf, ':', buf_len);
     if (p == NULL) {
 	fprintf (logfile, "ERROR: gdbstub_fe.packet '$X addr, len ...' packet from GDB: no ':' following len\n");
 	fprintf (logfile, "    addr = 0x%0" PRIx64 ", len = 0x%0" PRIx64 "\n", addr, length);
@@ -1367,18 +1377,18 @@ handle_RSP_X_write_mem_bin_data (const unsigned char *buf, const int buf_len)
 	return;
     }
     // Check that packet has 'length' data bytes
-    uint32_t num_bin_data_bytes = (buf_len - 1) - ((p + 1) - buf);
+    size_t num_bin_data_bytes = (buf_len - 1) - ((size_t) ((p + 1) - buf));
     if (num_bin_data_bytes != length) {
 	fprintf (logfile,
 		 "ERROR: gdbstub_fe.packet '$X addr, len: ...' packet from GDB: fewer than len binary data bytes\n");
 	fprintf (logfile, "    addr = 0x%0" PRIx64 ", len = 0x%0" PRIx64 "\n", addr, length);
-	fprintf (logfile, "    # of binary data data bytes = %0d\n", num_bin_data_bytes);
+	fprintf (logfile, "    # of binary data data bytes = %0zu\n", num_bin_data_bytes);
 	send_OK_or_error_response (0x03);
 	return;
     }
 
     // Write the data to the HW side
-    int status = gdbstub_be_mem_write (gdbstub_be_xlen, addr, (p + 1), length);
+    uint32_t status = gdbstub_be_mem_write (gdbstub_be_xlen, addr, (p + 1), length);
     send_OK_or_error_response (status);
 }
 
@@ -1400,20 +1410,20 @@ void *main_gdbstub (void *arg)
 	return NULL;
     }
 
-    unsigned char gdb_rsp_pkt_buf [GDB_RSP_PKT_BUF_MAX];
+    char gdb_rsp_pkt_buf [GDB_RSP_PKT_BUF_MAX];
 
     fprintf (logfile, "gdbstub v2.0\n");
     fflush (logfile);
 
     // Initialize the gdbstub_be
-    int status = gdbstub_be_init (logfile);
-    if (status != 0) {
+    uint32_t status = gdbstub_be_init (logfile);
+    if (status != status_ok) {
 	fprintf (logfile, "ERROR: gdbstub_fe.main_gdbstub: error in gdbstub_be_startup\n");
 	return NULL;
     }
 
     // Receive initial '+' from GDB
-    unsigned char ch = recv_ack_nak ();
+    char ch = recv_ack_nak ();
     if (ch != '+') {
 	fprintf (logfile, "ERROR: gdbstub_fe.main_gdbstub: Expecting initial '+', but received %c from GDB\n", ch);
 	return NULL;
@@ -1435,8 +1445,8 @@ void *main_gdbstub (void *arg)
 	    else if (sr == -1) {
                 // Timeout - interrupt the CPU. Send a "stop" command to the
                 // CPU.
-                int status = gdbstub_be_stop (gdbstub_be_xlen);
-                if (status != 0) {
+                uint32_t status = gdbstub_be_stop (gdbstub_be_xlen);
+                if (status != status_ok) {
                     send_OK_or_error_response (0x01);
 		    waiting_for_stop_reason = false;
                 }
@@ -1451,18 +1461,19 @@ void *main_gdbstub (void *arg)
 	}
 
 	// Receive RSP packet from GDB and despatch to appropriate handler
-	int n = recv_RSP_packet_from_GDB (gdb_rsp_pkt_buf, GDB_RSP_PKT_BUF_MAX);
+	ssize_t sn = recv_RSP_packet_from_GDB (gdb_rsp_pkt_buf, GDB_RSP_PKT_BUF_MAX);
 
-	if (n < 0) {
+	if (sn < 0) {
             fprintf (logfile, "ERROR: gdbstub_fe.on RSP Packet from GDB\n");
             break;
         }
-        else if (n == 0) {
+        else if (sn == 0) {
 	    // Complete packet not yet arrived from GDB
 	    //fprintf (logfile, "Complete packet not yet arrived from GDB\n");
 	    usleep (10);
 	    continue;
 	} else {
+	    size_t n = (size_t) sn;
             // fprint_bytes (logfile, "RX from GDB: '", gdb_rsp_pkt_buf, n - 1, "'\n");
 	    if (gdb_rsp_pkt_buf [0] == control_C) {
                 handle_RSP_control_C (gdb_rsp_pkt_buf, n);
@@ -1504,7 +1515,7 @@ void *main_gdbstub (void *arg)
                 handle_RSP_X_write_mem_bin_data (gdb_rsp_pkt_buf, n);
             }
             else {
-                fprintf (logfile, "WARNING: gdbstub_fe.main_gdbstub: Unrecognized packet (%0d chars): ", n - 1);
+                fprintf (logfile, "WARNING: gdbstub_fe.main_gdbstub: Unrecognized packet (%0zu chars): ", n - 1);
                 fprint_bytes (logfile, "", gdb_rsp_pkt_buf, n - 1, "\n");
 
                 send_RSP_packet_to_GDB ("", 0);
@@ -1513,6 +1524,7 @@ void *main_gdbstub (void *arg)
     }
 
     fclose (logfile);
+    return NULL;
 }
 
 // ================================================================

--- a/src/gdbstub_fe.c
+++ b/src/gdbstub_fe.c
@@ -1406,8 +1406,8 @@ void *main_gdbstub (void *arg)
 
     fprintf (logfile, "main_gdbstub: for RV%0d\n", gdbstub_be_xlen);
     if ((gdbstub_be_xlen != 32) && (gdbstub_be_xlen != 64)) {
-    fprintf (logfile, "ERROR: gdbstub_fe.main_gdbstub: invalid RVnn; nn should be 32 or 64 only\n");
-	return NULL;
+	fprintf (logfile, "ERROR: gdbstub_fe.main_gdbstub: invalid RVnn; nn should be 32 or 64 only\n");
+	goto done;
     }
 
     char gdb_rsp_pkt_buf [GDB_RSP_PKT_BUF_MAX];
@@ -1419,14 +1419,14 @@ void *main_gdbstub (void *arg)
     uint32_t status = gdbstub_be_init (logfile);
     if (status != status_ok) {
 	fprintf (logfile, "ERROR: gdbstub_fe.main_gdbstub: error in gdbstub_be_startup\n");
-	return NULL;
+	goto done;
     }
 
     // Receive initial '+' from GDB
     char ch = recv_ack_nak ();
     if (ch != '+') {
 	fprintf (logfile, "ERROR: gdbstub_fe.main_gdbstub: Expecting initial '+', but received %c from GDB\n", ch);
-	return NULL;
+	goto done;
     }
 
     // Loop, processing packets from GDB
@@ -1523,7 +1523,9 @@ void *main_gdbstub (void *arg)
         }
     }
 
+done:
     fclose (logfile);
+    close (gdb_fd);
     return NULL;
 }
 

--- a/src/gdbstub_fe.c
+++ b/src/gdbstub_fe.c
@@ -1663,11 +1663,13 @@ void *main_gdbstub (void *arg)
     }
 
 done:
-    if (logfile) {
-	fclose (logfile);
-    }
-    if (stop_fd >= 0) {
-	close (stop_fd);
+    if (params->autoclose_logfile_stop_fd) {
+	if (logfile) {
+	    fclose (logfile);
+	}
+	if (stop_fd >= 0) {
+	    close (stop_fd);
+	}
     }
     close (gdb_fd);
     return NULL;

--- a/src/gdbstub_fe.c
+++ b/src/gdbstub_fe.c
@@ -165,13 +165,15 @@ ssize_t gdb_escape (char *dst, const size_t dst_size, const char *src, const siz
     return (ssize_t) jd;
 
  err_dst_too_small:
-    fprintf (logfile, "ERROR: gdbstub_fe.gdb_escape: destination buffer too small\n");
-    fprintf (logfile, "    src [src_len %0zu] = \"", src_len);
-    size_t j;
-    for (j = 0; j < src_len; j++) fprintf (logfile, "%c", src [j]);
-    fprintf (logfile, "\"\n");
-    fprintf (logfile, "    dst_size = %0zu\n", dst_size);
-    fprintf (logfile, "    At src [%0zu], dst [%0zu]\n", js, jd);
+    if (logfile) {
+	fprintf (logfile, "ERROR: gdbstub_fe.gdb_escape: destination buffer too small\n");
+	fprintf (logfile, "    src [src_len %0zu] = \"", src_len);
+	size_t j;
+	for (j = 0; j < src_len; j++) fprintf (logfile, "%c", src [j]);
+	fprintf (logfile, "\"\n");
+	fprintf (logfile, "    dst_size = %0zu\n", dst_size);
+	fprintf (logfile, "    At src [%0zu], dst [%0zu]\n", js, jd);
+    }
     return -1;
 }
 
@@ -213,20 +215,25 @@ ssize_t gdb_unescape (char *dst, const size_t dst_size, const char *src, const s
     return (ssize_t) jd;
 
  err_dst_too_small:
-    fprintf (logfile, "ERROR: gdbstub_fe.gdb_unescape: destination buffer too small\n");
-    fprintf (logfile, "    src [src_len %0zu] = \"", src_len);
-    size_t j;
-    for (j = 0; j < src_len; j++) fprintf (logfile, "%c", src [j]);
-    fprintf (logfile, "\"\n");
-    fprintf (logfile, "    dst_size = %0zu\n", dst_size);
-    fprintf (logfile, "    At src [%0zu], dst [%0zu]\n", js, jd);
+    if (logfile) {
+	fprintf (logfile, "ERROR: gdbstub_fe.gdb_unescape: destination buffer too small\n");
+	fprintf (logfile, "    src [src_len %0zu] = \"", src_len);
+	size_t j;
+	for (j = 0; j < src_len; j++) fprintf (logfile, "%c", src [j]);
+	fprintf (logfile, "\"\n");
+	fprintf (logfile, "    dst_size = %0zu\n", dst_size);
+	fprintf (logfile, "    At src [%0zu], dst [%0zu]\n", js, jd);
+    }
     return -1;
 
  err_ends_in_escape_char:
-    fprintf (logfile, "ERROR: gdbstub_fe.gdb_unescape: last char of src is escape char\n");
-    fprintf (logfile, "    src [src_len %0zu] = \"", src_len);
-    for (j = 0; j < src_len; j++) fprintf (logfile, "%c", src [j]);
-    fprintf (logfile, "\"\n");
+    if (logfile) {
+	fprintf (logfile, "ERROR: gdbstub_fe.gdb_unescape: last char of src is escape char\n");
+	fprintf (logfile, "    src [src_len %0zu] = \"", src_len);
+	size_t j;
+	for (j = 0; j < src_len; j++) fprintf (logfile, "%c", src [j]);
+	fprintf (logfile, "\"\n");
+    }
     return -1;
 }
 
@@ -291,21 +298,27 @@ int send_ack_nak (char ack_char)
     while (true) {
 	ssize_t n = write (gdb_fd, & ack_char, 1);
 	if (n < 0) {
-	    fprintf (logfile, "ERROR: gdbstub_fe.send_ack_nak: write (ack_char '%c') failed\n", ack_char);
+	    if (logfile) {
+		fprintf (logfile, "ERROR: gdbstub_fe.send_ack_nak: write (ack_char '%c') failed\n", ack_char);
+	    }
 	    perror (NULL);
 	    return -1;
 	}
 	else if (n == 0) {
 	    if (n_iters > 1000000) {
-		fprintf (logfile, "ERROR: gdbstub_fe.send_ack_nak: nothing sent in 1,000,000 write () attempts\n");
+		if (logfile) {
+		    fprintf (logfile, "ERROR: gdbstub_fe.send_ack_nak: nothing sent in 1,000,000 write () attempts\n");
+		}
 		return -1;
 	    }
 	    usleep (5);
 	    n_iters++;
 	}
 	else {
-	    fprintf (logfile, "w %c\n", ack_char);
-	    fflush (logfile);
+	    if (logfile) {
+		fprintf (logfile, "w %c\n", ack_char);
+		fflush (logfile);
+	    }
 	    return 0;
 	}
     }
@@ -327,8 +340,10 @@ char recv_ack_nak (void)
 	    if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
 		// Nothing available yet
 		if (n_iters > n_iters_max) {
-		    fprintf (logfile, "ERROR: gdbstub_fe.recv_ack_nak: nothing received in %0zu read () attempts\n",
-			     n_iters_max);
+		    if (logfile) {
+			fprintf (logfile, "ERROR: gdbstub_fe.recv_ack_nak: nothing received in %0zu read () attempts\n",
+				 n_iters_max);
+		    }
 		    return 'E';
 		}
 		else {
@@ -337,27 +352,35 @@ char recv_ack_nak (void)
 		}
 	    }
 	    else {
-		fprintf (logfile, "ERROR: gdbstub_fe.recv_ack_nak: read () failed\n");
+		if (logfile) {
+		    fprintf (logfile, "ERROR: gdbstub_fe.recv_ack_nak: read () failed\n");
+		}
 		return 'E';
 	    }
 	}
 	else if (n == 0) {
 	    if (n_iters > n_iters_max) {
-		fprintf (logfile, "ERROR: gdbstub_fe.recv_ack_nak: nothing received in %0zu read () attempts\n",
-			 n_iters_max);
+		if (logfile) {
+		    fprintf (logfile, "ERROR: gdbstub_fe.recv_ack_nak: nothing received in %0zu read () attempts\n",
+			     n_iters_max);
+		}
 		return 'E';
 	    }
 	    usleep (5);
 	    n_iters++;
 	}
 	else if ((ack_char == '+') || (ack_char == '-')) {
-	    fprintf (logfile, "r %c\n", ack_char);
-	    fflush (logfile);
+	    if (logfile) {
+		fprintf (logfile, "r %c\n", ack_char);
+		fflush (logfile);
+	    }
 	    return ack_char;
 	}
 	else {
-	    fprintf (logfile, "ERROR: gdbstub_fe.recv_ack_nak: received unexpected char 0x%0x ('%c') \n",
-		     ack_char, ack_char);
+	    if (logfile) {
+		fprintf (logfile, "ERROR: gdbstub_fe.recv_ack_nak: received unexpected char 0x%0x ('%c') \n",
+			 ack_char, ack_char);
+	    }
 	    return 'E';
 	}
     }
@@ -373,10 +396,12 @@ uint8_t value_of_hex_digit (char ch)
     else if ((ch >= 'A') && (ch <= 'F')) return (uint8_t) (ch - 'A' + 10);
     else if ((ch >= '0') && (ch <= '9')) return (uint8_t) (ch - '0');
     else {
-	fprintf (logfile, "ERROR: gdbstub_fe.value_of_hex_digit () argument is not a hex digit\n");
-	fprintf (logfile, "    arg value is: ");
-	fprint_byte (logfile, ch);
-	fprintf (logfile, "\n");
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.value_of_hex_digit () argument is not a hex digit\n");
+	    fprintf (logfile, "    arg value is: ");
+	    fprint_byte (logfile, ch);
+	    fprintf (logfile, "\n");
+	}
 	return 0xFF;
     }
 }
@@ -518,8 +543,10 @@ uint32_t send_RSP_packet_to_GDB (const char *buf, const size_t buf_len)
     // Copy the payload from buf to wire_buf, escaping bytes as necessary
     ssize_t s_wire_len = gdb_escape (& (wire_buf [1]), (GDB_RSP_WIRE_BUF_MAX - 1), buf, buf_len);
     if ((s_wire_len < 0) || ((s_wire_len + 4) >= GDB_RSP_WIRE_BUF_MAX)) {
-	fprintf (logfile, "ERROR: gdbstub_fe.send_RSP_packet_to_GDB: packet too large\n");
-	fprintf (logfile, "    Encoded packet will not fit in wire_buf [%0d]\n", GDB_RSP_WIRE_BUF_MAX);
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.send_RSP_packet_to_GDB: packet too large\n");
+	    fprintf (logfile, "    Encoded packet will not fit in wire_buf [%0d]\n", GDB_RSP_WIRE_BUF_MAX);
+	}
 	goto err_exit;
     }
 
@@ -540,13 +567,17 @@ uint32_t send_RSP_packet_to_GDB (const char *buf, const size_t buf_len)
 	while (n_sent < (wire_len + 4)) {
 	    ssize_t n = write (gdb_fd, & (wire_buf [n_sent]), (wire_len + 4 - n_sent));
 	    if (n < 0) {
-		fprintf (logfile, "ERROR: gdbstub_fe.send_RSP_packet_to_GDB: write (wire_buf) failed\n");
+		if (logfile) {
+		    fprintf (logfile, "ERROR: gdbstub_fe.send_RSP_packet_to_GDB: write (wire_buf) failed\n");
+		}
 		goto err_exit;
 	    }
 	    else if (n == 0) {
 		if (n_iters > 1000000) {
-		    fprintf (logfile,
-			     "ERROR: gdbstub_fe.send_RSP_packet_to_GDB: nothing sent in 1,000,000 write () attempts\n");
+		    if (logfile) {
+			fprintf (logfile,
+				 "ERROR: gdbstub_fe.send_RSP_packet_to_GDB: nothing sent in 1,000,000 write () attempts\n");
+		    }
 		    goto err_exit;
 		}
 		usleep (5);
@@ -557,23 +588,29 @@ uint32_t send_RSP_packet_to_GDB (const char *buf, const size_t buf_len)
 	    }
 	}
 	// Debug
-	fprint_bytes (logfile, "w ", wire_buf, wire_len + 4, "\n");
+	if (logfile) {
+	    fprint_bytes (logfile, "w ", wire_buf, wire_len + 4, "\n");
+	}
 
 	// Receive '+' (ack) or '-' (nak) from GDB
 	char ch = recv_ack_nak ();
 	if (ch == '+')
 	    return status_ok;
 	else {
-	    fprintf (logfile, "Received nak ('-') from GDB\n");
+	    if (logfile) {
+		fprintf (logfile, "Received nak ('-') from GDB\n");
+	    }
 	    continue; // goto err_exit;
 	}
     }
 
  err_exit:
-    fprintf (logfile, "    buf [buf_len %0zu] = \"", buf_len);
-    size_t j;
-    for (j = 0; j < buf_len; j++) fprintf (logfile, "%c", buf [j]);
-    fprintf (logfile, "\"\n");
+    if (logfile) {
+	fprintf (logfile, "    buf [buf_len %0zu] = \"", buf_len);
+	size_t j;
+	for (j = 0; j < buf_len; j++) fprintf (logfile, "%c", buf [j]);
+	fprintf (logfile, "\"\n");
+    }
     return status_err;
 }
 
@@ -620,13 +657,17 @@ ssize_t recv_RSP_packet_from_GDB (char *buf, const size_t buf_size)
 		// Nothing available
 	    }
 	    else {
-		fprintf (logfile, "ERROR: gdbstub_fe.recv_RSP_packet_from_GDB: read () failed\n");
+		if (logfile) {
+		    fprintf (logfile, "ERROR: gdbstub_fe.recv_RSP_packet_from_GDB: read () failed\n");
+		}
 		return -1;
 	    }
 	}
 	else if (n == 0) {
 	    // eof
-	    fprintf (logfile, "recv_RSP_packet_from_GDB: read () ==> EOF\n");
+	    if (logfile) {
+		fprintf (logfile, "recv_RSP_packet_from_GDB: read () ==> EOF\n");
+	    }
 	    return -1;
 	}
 	else {
@@ -640,17 +681,19 @@ ssize_t recv_RSP_packet_from_GDB (char *buf, const size_t buf_size)
 	start++;
     }
 
-    if (DEBUG_recv_RSP_packet_from_GDB) {
-        fprintf (logfile,
-                "recv_RSP_packet_from_GDB:DBG: free_ptr=%zu, n=%zd, start=%zu\n",
-                free_ptr, n, start);
+    if (DEBUG_recv_RSP_packet_from_GDB && logfile) {
+	fprintf (logfile,
+		"recv_RSP_packet_from_GDB:DBG: free_ptr=%zu, n=%zd, start=%zu\n",
+		free_ptr, n, start);
     }
 
     // discard garbage before packet, if any
     if (start != 0) {
-	fprintf (logfile, "WARNING: gdbstub_fe.recv_RSP_packet_from_GDB: %0zu junk chars before '$'; ignoring:\n",
-		 start);
-	fprint_bytes (logfile, "    [", wire_buf, start, "]\n");
+	if (logfile) {
+	    fprintf (logfile, "WARNING: gdbstub_fe.recv_RSP_packet_from_GDB: %0zu junk chars before '$'; ignoring:\n",
+		     start);
+	    fprint_bytes (logfile, "    [", wire_buf, start, "]\n");
+	}
 
 	memmove (wire_buf, & (wire_buf [start]), free_ptr - start);
 	free_ptr -= start;
@@ -662,21 +705,25 @@ ssize_t recv_RSP_packet_from_GDB (char *buf, const size_t buf_size)
     }
 
     // Debug:
-    if (DEBUG_recv_RSP_packet_from_GDB) {
-        fprint_bytes (logfile, "recv_RSP_packet_from_GDB:DBG: ", wire_buf, (free_ptr-1), "\n");
+    if (DEBUG_recv_RSP_packet_from_GDB && logfile) {
+	fprint_bytes (logfile, "recv_RSP_packet_from_GDB:DBG: ", wire_buf, (free_ptr-1), "\n");
     }
     // Check for ^C
     if (wire_buf [0] == control_C) {
 	if (buf_size < 2) {
-	    fprintf (logfile, "ERROR: gdbstub_fe.recv_RSP_packet_from_GDB: buf_size too small: %0zu\n", buf_size);
+	    if (logfile) {
+		fprintf (logfile, "ERROR: gdbstub_fe.recv_RSP_packet_from_GDB: buf_size too small: %0zu\n", buf_size);
+	    }
 	    return -1;
 	}
 
 	// Debug:
-        fprintf (logfile, "r \\x%02x\n", control_C);
-        if (DEBUG_recv_RSP_packet_from_GDB) {
-            fprintf (logfile, "recv_RSP_packet_from_GDB: returning ctrl+c\n");
-        }
+	if (logfile) {
+	    fprintf (logfile, "r \\x%02x\n", control_C);
+	    if (DEBUG_recv_RSP_packet_from_GDB) {
+		fprintf (logfile, "recv_RSP_packet_from_GDB: returning ctrl+c\n");
+	    }
+	}
 
 	// Discard the packet
 	memmove (wire_buf, & (wire_buf [1]), (free_ptr - 1));
@@ -708,7 +755,9 @@ ssize_t recv_RSP_packet_from_GDB (char *buf, const size_t buf_size)
     // We will send either a '+' or a '-' acknowledgement.
 
     // Debug:
-    fprint_packet (logfile, "r ", wire_buf, end + 3, "\n");
+    if (logfile) {
+	fprint_packet (logfile, "r ", wire_buf, end + 3, "\n");
+    }
 
     // Compute the checksum of the received chars
     uint8_t computed_checksum = gdb_checksum (& (wire_buf [1]), (end - 1));
@@ -724,10 +773,12 @@ ssize_t recv_RSP_packet_from_GDB (char *buf, const size_t buf_size)
 	// checksum failed
 	ack_char = '-';
 	ret = -1;
-	fprintf (logfile,
-		 "ERROR: gdbstub_fe.recv_RSP_packet_from_GDB: computed checksum 0x%02x; received checksum 0x%02x\n",
-		 computed_checksum,
-		 received_checksum);
+	if (logfile) {
+	    fprintf (logfile,
+		     "ERROR: gdbstub_fe.recv_RSP_packet_from_GDB: computed checksum 0x%02x; received checksum 0x%02x\n",
+		     computed_checksum,
+		     received_checksum);
+	}
     }
     else {
 	// checksum passed
@@ -927,8 +978,10 @@ void handle_RSP_G_write_all_registers (const char *buf, const size_t buf_len)
 
     // Check that the packet has the right number of hex digits for all the regs
     if (buf_len != 33 * num_ASCII_hex_digits) {
-	fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): invalid buf_len (%0zu)\n", buf_len);
-	fprintf (logfile, "    Expecting exactly 33 x %0zu hex digits\n", num_ASCII_hex_digits);
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): invalid buf_len (%0zu)\n", buf_len);
+	    fprintf (logfile, "    Expecting exactly 33 x %0zu hex digits\n", num_ASCII_hex_digits);
+	}
 	goto error_response;
     }
 
@@ -937,8 +990,10 @@ void handle_RSP_G_write_all_registers (const char *buf, const size_t buf_len)
     for (j = 0; j < 32; j++) {
 	status = hex16_to_val (& (buf [j * num_ASCII_hex_digits]), gdbstub_be_xlen, & (GPR_vals [j]));
 	if (status != status_ok) {
-	    fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): error parsing val for reg %0u\n",
-		     j);
+	    if (logfile) {
+		fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): error parsing val for reg %0u\n",
+			 j);
+	    }
 	    goto error_response;
 	}
     }
@@ -946,7 +1001,9 @@ void handle_RSP_G_write_all_registers (const char *buf, const size_t buf_len)
     // Parse the PC value
     status = hex16_to_val (& (buf [32 * num_ASCII_hex_digits]), gdbstub_be_xlen, & PC_val);
     if (status != status_ok) {
-	fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): error parsing val for PC\n");
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): error parsing val for PC\n");
+	}
 	goto error_response;
     }
 
@@ -954,8 +1011,10 @@ void handle_RSP_G_write_all_registers (const char *buf, const size_t buf_len)
     for (j = 0; j < 32; j++) {
 	status = gdbstub_be_GPR_write (gdbstub_be_xlen, j, GPR_vals [j]);
 	if (status != status_ok) {
-	    fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): error writing val for reg %0u\n",
-		     j);
+	    if (logfile) {
+		fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): error writing val for reg %0u\n",
+			 j);
+	    }
 	    goto error_response;
 	}
     }
@@ -963,7 +1022,9 @@ void handle_RSP_G_write_all_registers (const char *buf, const size_t buf_len)
     // Write PC to HW
     status = gdbstub_be_PC_write (gdbstub_be_xlen, PC_val);
     if (status != status_ok) {
-	fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): error writing val for PC\n");
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_G_write_all_registers (): error writing val for PC\n");
+	}
 	goto error_response;
     }
 
@@ -973,7 +1034,9 @@ void handle_RSP_G_write_all_registers (const char *buf, const size_t buf_len)
     send_OK_or_error_response (0);
 
  error_response:
-    fprint_bytes (logfile, "    buf: ", buf, buf_len-1, "\n");
+    if (logfile) {
+	fprint_bytes (logfile, "    buf: ", buf, buf_len-1, "\n");
+    }
     send_OK_or_error_response (0x01);
     return;
 }
@@ -989,7 +1052,9 @@ void handle_RSP_m_read_mem (const char *buf, const size_t buf_len)
     size_t length;
 
     if (2 != sscanf (buf, "m%" SCNx64 ",%zx", & addr, & length)) {
-	fprintf (logfile, "ERROR: gdbstub_fe.packet '$m...' packet from GDB: unable to parse addr, len\n");
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.packet '$m...' packet from GDB: unable to parse addr, len\n");
+	}
 	send_OK_or_error_response (0x01);
 	return;
     }
@@ -1004,7 +1069,9 @@ void handle_RSP_m_read_mem (const char *buf, const size_t buf_len)
     // Get memory data from HW
     uint32_t status = gdbstub_be_mem_read (gdbstub_be_xlen, addr, buf_bin, length);
     if (status != status_ok) {
-	fprintf (logfile, "ERROR: gdbstub_fe.packet '$m...' packet from GDB: error reading HW memory\n");
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.packet '$m...' packet from GDB: error reading HW memory\n");
+	}
 	send_OK_or_error_response (0x01);
 	return;
     }
@@ -1028,7 +1095,9 @@ handle_RSP_M_write_mem_hex_data (const char *buf, const size_t buf_len)
     size_t length;
 
     if (2 != sscanf (buf, "M%" SCNx64 ",%zx", & addr, & length)) {
-	fprintf (logfile, "ERROR: gdbstub_fe: packet '$M...' packet from GDB: unable to parse addr, len\n");
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe: packet '$M...' packet from GDB: unable to parse addr, len\n");
+	}
 	send_OK_or_error_response (0x01);
 	return;
     }
@@ -1036,8 +1105,10 @@ handle_RSP_M_write_mem_hex_data (const char *buf, const size_t buf_len)
     // Find ':' separating length from bin data
     char *p = memchr (buf, ':', buf_len);
     if (p == NULL) {
-	fprintf (logfile, "ERROR: gdbstub_fe: packet '$M addr, len ...' packet from GDB: no ':' following len\n");
-	fprintf (logfile, "    addr = 0x%0" PRIx64 ", len = 0x%0" PRIx64 "\n", addr, length);
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe: packet '$M addr, len ...' packet from GDB: no ':' following len\n");
+	    fprintf (logfile, "    addr = 0x%0" PRIx64 ", len = 0x%0" PRIx64 "\n", addr, length);
+	}
 	send_OK_or_error_response (0x01);
 	return;
     }
@@ -1045,11 +1116,13 @@ handle_RSP_M_write_mem_hex_data (const char *buf, const size_t buf_len)
     // Check that it has the correct number of hex digits
     size_t num_hex_data_digits = (buf_len - 1) - ((size_t) ((p + 1) - buf));
     if (num_hex_data_digits != (length * 2)) {
-	fprintf (logfile,
-		 "ERROR: gdbstub_fe.packet '$M addr, len: ...' packet from GDB: fewer than (len*2) hex digits\n");
-	fprintf (logfile, "    addr = 0x%0" PRIx64 ", len = 0x%0" PRIx64 "\n", addr, length);
-	fprintf (logfile, "    # of hex data digits = %0zu; len * 2 = 0x%0" PRId64 "\n",
-		 num_hex_data_digits, length * 2);
+	if (logfile) {
+	    fprintf (logfile,
+		     "ERROR: gdbstub_fe.packet '$M addr, len: ...' packet from GDB: fewer than (len*2) hex digits\n");
+	    fprintf (logfile, "    addr = 0x%0" PRIx64 ", len = 0x%0" PRIx64 "\n", addr, length);
+	    fprintf (logfile, "    # of hex data digits = %0zu; len * 2 = 0x%0" PRId64 "\n",
+		     num_hex_data_digits, length * 2);
+	}
 	send_OK_or_error_response (0x03);
 	return;
     }
@@ -1117,8 +1190,10 @@ void handle_RSP_p_read_register (const char *buf, const size_t buf_len)
 	}
     }
     else {
-	fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_p_read_register: unknown reg number: 0x%0x\n",
-		 regnum);
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_p_read_register: unknown reg number: 0x%0x\n",
+		     regnum);
+	}
 	send_OK_or_error_response (0x01);
 	return;
     }
@@ -1144,7 +1219,9 @@ void handle_RSP_P_write_register (const char *buf, const size_t buf_len)
 
     // Parse the regnum
     if (1 != sscanf (buf, "P%x", & regnum)) {
-	fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_P_write_register (): error parsing register num\n");
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_P_write_register (): error parsing register num\n");
+	}
 	status = 0x01;
 	goto done;
     }
@@ -1152,7 +1229,9 @@ void handle_RSP_P_write_register (const char *buf, const size_t buf_len)
     // Find and skip past '='
     char *p = memchr (buf, '=', buf_len);
     if (p == NULL) {
-	fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_P_write_register (): no '=' after register num\n");
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_P_write_register (): no '=' after register num\n");
+	}
 	status = 0x01;
 	goto done;
     }
@@ -1161,8 +1240,10 @@ void handle_RSP_P_write_register (const char *buf, const size_t buf_len)
     // Parse the register value
     status = hex16_to_val (p, gdbstub_be_xlen, & regval);
     if (status != status_ok) {
-	fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_P_write_register (): error parsing value for register %0d\n",
-		 regnum);
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_P_write_register (): error parsing value for register %0d\n",
+		     regnum);
+	}
 	status = 0x01;
 	goto done;
     }
@@ -1187,7 +1268,7 @@ void handle_RSP_P_write_register (const char *buf, const size_t buf_len)
 	status = 01;
 
  done:
-    if (status != status_ok) {
+    if ((status != status_ok) && logfile) {
 	fprintf (logfile, "ERROR: gdbstub_fe.handle_RSP_P_write_register: gdbstub_be write error\n");
 	fprintf (logfile, "    regnum 0x%0x, regval 0x%0" PRIx64 "\n", regnum, regval);
     }
@@ -1256,7 +1337,9 @@ handle_RSP_qRcmd (const char *buf, const size_t buf_len)
 
     else {
 	// Unrecognized command
-	// fprintf (logfile, "Monitor command not recognized\n");
+	// if (logfile) {
+	//     fprintf (logfile, "Monitor command not recognized\n");
+	// }
 	send_RSP_packet_to_GDB ("", 0);
 	return;
     }
@@ -1303,8 +1386,10 @@ handle_RSP_q (const char *buf, const size_t buf_len)
     }
 
     else {
-	fprintf (logfile, "WARNING: gdbstub_fe.handle_RSP_q: Unrecognized packet (%0zu chars): ", buf_len - 1);
-	fprint_bytes (logfile, "", buf, buf_len - 1, "\n");
+	if (logfile) {
+	    fprintf (logfile, "WARNING: gdbstub_fe.handle_RSP_q: Unrecognized packet (%0zu chars): ", buf_len - 1);
+	    fprint_bytes (logfile, "", buf, buf_len - 1, "\n");
+	}
 
 	char response [] = "";
 	send_RSP_packet_to_GDB (response, strlen (response));
@@ -1363,7 +1448,9 @@ handle_RSP_X_write_mem_bin_data (const char *buf, const size_t buf_len)
     uint64_t addr, length;
 
     if (2 != sscanf (buf, "X%" SCNx64 ",%" SCNx64 "", & addr, & length)) {
-	fprintf (logfile, "ERROR: gdbstub_fe.packet '$X...' packet from GDB: unable to parse addr, len\n");
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.packet '$X...' packet from GDB: unable to parse addr, len\n");
+	}
 	send_OK_or_error_response (0x01);
 	return;
     }
@@ -1371,18 +1458,22 @@ handle_RSP_X_write_mem_bin_data (const char *buf, const size_t buf_len)
     // Find ':' separating length from bin data
     char *p = memchr (buf, ':', buf_len);
     if (p == NULL) {
-	fprintf (logfile, "ERROR: gdbstub_fe.packet '$X addr, len ...' packet from GDB: no ':' following len\n");
-	fprintf (logfile, "    addr = 0x%0" PRIx64 ", len = 0x%0" PRIx64 "\n", addr, length);
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.packet '$X addr, len ...' packet from GDB: no ':' following len\n");
+	    fprintf (logfile, "    addr = 0x%0" PRIx64 ", len = 0x%0" PRIx64 "\n", addr, length);
+	}
 	send_OK_or_error_response (0x01);
 	return;
     }
     // Check that packet has 'length' data bytes
     size_t num_bin_data_bytes = (buf_len - 1) - ((size_t) ((p + 1) - buf));
     if (num_bin_data_bytes != length) {
-	fprintf (logfile,
-		 "ERROR: gdbstub_fe.packet '$X addr, len: ...' packet from GDB: fewer than len binary data bytes\n");
-	fprintf (logfile, "    addr = 0x%0" PRIx64 ", len = 0x%0" PRIx64 "\n", addr, length);
-	fprintf (logfile, "    # of binary data data bytes = %0zu\n", num_bin_data_bytes);
+	if (logfile) {
+	    fprintf (logfile,
+		     "ERROR: gdbstub_fe.packet '$X addr, len: ...' packet from GDB: fewer than len binary data bytes\n");
+	    fprintf (logfile, "    addr = 0x%0" PRIx64 ", len = 0x%0" PRIx64 "\n", addr, length);
+	    fprintf (logfile, "    # of binary data data bytes = %0zu\n", num_bin_data_bytes);
+	}
 	send_OK_or_error_response (0x03);
 	return;
     }
@@ -1404,28 +1495,38 @@ void *main_gdbstub (void *arg)
     gdb_fd  = params->gdb_fd;
     logfile = params->logfile;
 
-    fprintf (logfile, "main_gdbstub: for RV%0d\n", gdbstub_be_xlen);
+    if (logfile) {
+	fprintf (logfile, "main_gdbstub: for RV%0d\n", gdbstub_be_xlen);
+    }
     if ((gdbstub_be_xlen != 32) && (gdbstub_be_xlen != 64)) {
-	fprintf (logfile, "ERROR: gdbstub_fe.main_gdbstub: invalid RVnn; nn should be 32 or 64 only\n");
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.main_gdbstub: invalid RVnn; nn should be 32 or 64 only\n");
+	}
 	goto done;
     }
 
     char gdb_rsp_pkt_buf [GDB_RSP_PKT_BUF_MAX];
 
-    fprintf (logfile, "gdbstub v2.0\n");
-    fflush (logfile);
+    if (logfile) {
+	fprintf (logfile, "gdbstub v2.0\n");
+	fflush (logfile);
+    }
 
     // Initialize the gdbstub_be
     uint32_t status = gdbstub_be_init (logfile);
     if (status != status_ok) {
-	fprintf (logfile, "ERROR: gdbstub_fe.main_gdbstub: error in gdbstub_be_startup\n");
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.main_gdbstub: error in gdbstub_be_startup\n");
+	}
 	goto done;
     }
 
     // Receive initial '+' from GDB
     char ch = recv_ack_nak ();
     if (ch != '+') {
-	fprintf (logfile, "ERROR: gdbstub_fe.main_gdbstub: Expecting initial '+', but received %c from GDB\n", ch);
+	if (logfile) {
+	    fprintf (logfile, "ERROR: gdbstub_fe.main_gdbstub: Expecting initial '+', but received %c from GDB\n", ch);
+	}
 	goto done;
     }
 
@@ -1456,7 +1557,9 @@ void *main_gdbstub (void *arg)
 	    else {
 		// HW has not stopped yet
 		assert (sr == -2);
-                //fprintf (logfile, "main_gdbstub: HW has not stopped yet.\n");
+		// if (logfile) {
+		//     fprintf (logfile, "main_gdbstub: HW has not stopped yet.\n");
+		// }
 	    }
 	}
 
@@ -1464,17 +1567,23 @@ void *main_gdbstub (void *arg)
 	ssize_t sn = recv_RSP_packet_from_GDB (gdb_rsp_pkt_buf, GDB_RSP_PKT_BUF_MAX);
 
 	if (sn < 0) {
-            fprintf (logfile, "ERROR: gdbstub_fe.on RSP Packet from GDB\n");
+	    if (logfile) {
+		fprintf (logfile, "ERROR: gdbstub_fe.on RSP Packet from GDB\n");
+	    }
             break;
         }
         else if (sn == 0) {
 	    // Complete packet not yet arrived from GDB
-	    //fprintf (logfile, "Complete packet not yet arrived from GDB\n");
+	    // if (logfile) {
+	    //     fprintf (logfile, "Complete packet not yet arrived from GDB\n");
+	    // }
 	    usleep (10);
 	    continue;
 	} else {
 	    size_t n = (size_t) sn;
-            // fprint_bytes (logfile, "RX from GDB: '", gdb_rsp_pkt_buf, n - 1, "'\n");
+	    // if (logfile) {
+	    //     fprint_bytes (logfile, "RX from GDB: '", gdb_rsp_pkt_buf, n - 1, "'\n");
+	    // }
 	    if (gdb_rsp_pkt_buf [0] == control_C) {
                 handle_RSP_control_C (gdb_rsp_pkt_buf, n);
             }
@@ -1515,8 +1624,10 @@ void *main_gdbstub (void *arg)
                 handle_RSP_X_write_mem_bin_data (gdb_rsp_pkt_buf, n);
             }
             else {
-                fprintf (logfile, "WARNING: gdbstub_fe.main_gdbstub: Unrecognized packet (%0zu chars): ", n - 1);
-                fprint_bytes (logfile, "", gdb_rsp_pkt_buf, n - 1, "\n");
+		if (logfile) {
+		    fprintf (logfile, "WARNING: gdbstub_fe.main_gdbstub: Unrecognized packet (%0zu chars): ", n - 1);
+		    fprint_bytes (logfile, "", gdb_rsp_pkt_buf, n - 1, "\n");
+		}
 
                 send_RSP_packet_to_GDB ("", 0);
             }
@@ -1524,7 +1635,9 @@ void *main_gdbstub (void *arg)
     }
 
 done:
-    fclose (logfile);
+    if (logfile) {
+	fclose (logfile);
+    }
     close (gdb_fd);
     return NULL;
 }

--- a/src/gdbstub_fe.h
+++ b/src/gdbstub_fe.h
@@ -25,6 +25,10 @@ typedef struct {
     // a byte can be read. Use -1 to disable.
     int   stop_fd;
 
+    // Whether to automatically close logfile and stop_fd. gdb_fd is
+    // always closed.
+    bool  autoclose_logfile_stop_fd;
+
 } Gdbstub_FE_Params;
 
 // ================================================================

--- a/src/gdbstub_fe.h
+++ b/src/gdbstub_fe.h
@@ -21,6 +21,10 @@ typedef struct {
     // File descriptor for read/write of RSP messages from/to GDB
     int   gdb_fd;
 
+    // Optional file descriptor for stopping GDB server; stops when
+    // a byte can be read. Use -1 to disable.
+    int   stop_fd;
+
 } Gdbstub_FE_Params;
 
 // ================================================================

--- a/src/main.c
+++ b/src/main.c
@@ -2,7 +2,7 @@
 
 #include "gdbstub_fe.h"
 
-int main (int argc, char *argv)
+int main (int argc, char **argv)
 {
     Gdbstub_FE_Params params;
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdbool.h>
 
 #include "gdbstub_fe.h"
 


### PR DESCRIPTION
The internal frontend is still a bit rough around the edges in terms of giving errors for various basic operations that really should work, but it's at least now in a state where GDB can connect/disconnect multiple times, inspect the register file and examine memory. The wrappers I've added provide an abstraction around the frontend parts so it's almost trivial to drop into any project that either has a file descriptor to hand or wants a TCP-based server on localhost, handling all the nitty-gritty of sockets for you.

Some of the casts here are somewhat unnecessary (either because they're impossible to hit due to higher-level knowledge, or GCC is too stupid to do even basic analysis based on things like being inside the `else` of an `if (n < 0) ... else ...`), but given that -Wconversion did turn up various genuine issues of UB I think it's valuable to be clean of all such warnings.